### PR TITLE
Refactor race planning and centralize settings

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -6,9 +6,10 @@ from extensions import db
 from models import User, Race, Pig, CerealItem, TrainingItem, SchoolLessonItem
 from data import JOURS_FR
 from helpers import (
-    get_config, set_config, populate_race_participants, run_race_if_needed,
+    set_config, populate_race_participants, run_race_if_needed,
     get_all_cereals_dict, get_all_trainings_dict, get_all_school_lessons_dict,
 )
+from services.game_settings_service import get_game_settings
 
 admin_bp = Blueprint('admin', __name__)
 
@@ -28,18 +29,19 @@ def admin():
     next_race = Race.query.filter(Race.status == 'open').order_by(Race.scheduled_at).first()
     recent_races = Race.query.filter_by(status='finished').order_by(Race.finished_at.desc()).limit(10).all()
 
+    settings = get_game_settings()
     return render_template('admin.html',
         user=user, users=users, pigs=pigs, upcoming_races=upcoming_races,
         next_race=next_race, recent_races=recent_races,
         config={
-            'race_hour': get_config('race_hour', '14'),
-            'race_minute': get_config('race_minute', '00'),
-            'market_day': get_config('market_day', '4'),
-            'market_hour': get_config('market_hour', '13'),
-            'market_minute': get_config('market_minute', '45'),
-            'market_duration': get_config('market_duration', '120'),
-            'min_real_participants': get_config('min_real_participants', '2'),
-            'empty_race_mode': get_config('empty_race_mode', 'fill'),
+            'race_hour': settings.race_hour,
+            'race_minute': settings.race_minute,
+            'market_day': settings.market_day,
+            'market_hour': settings.market_hour,
+            'market_minute': settings.market_minute,
+            'market_duration': settings.market_duration,
+            'min_real_participants': settings.min_real_participants,
+            'empty_race_mode': settings.empty_race_mode,
         },
         jours=JOURS_FR
     )

--- a/routes/market.py
+++ b/routes/market.py
@@ -6,10 +6,11 @@ from extensions import db
 from models import User, Pig, Auction
 from data import RARITIES, PIG_ORIGINS, JOURS_FR, DEFAULT_PIG_WEIGHT_KG
 from helpers import (
-    get_market_unlock_progress, get_market_lock_reason, get_config,
+    get_market_unlock_progress, get_market_lock_reason,
     is_market_open, get_next_market_time, get_market_close_time,
     get_prix_moyen_groin, apply_row_lock,
 )
+from services.game_settings_service import get_game_settings
 
 market_bp = Blueprint('market', __name__)
 
@@ -30,10 +31,11 @@ def marche():
             market_access = get_market_unlock_progress(user)[0]
             market_lock_reason = get_market_lock_reason(user)
 
+    settings = get_game_settings()
     market_open = is_market_open()
     next_market = get_next_market_time()
-    market_day_name = JOURS_FR[int(get_config('market_day', '4'))]
-    market_time = f"{get_config('market_hour', '13')}h{get_config('market_minute', '45')}"
+    market_day_name = JOURS_FR[settings.market_day]
+    market_time = f"{settings.market_hour}h{settings.market_minute:02d}"
     prix_groin = get_prix_moyen_groin()
 
     return render_template('marche.html',

--- a/routes/race.py
+++ b/routes/race.py
@@ -1,17 +1,16 @@
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash
 from sqlalchemy.exc import IntegrityError
-from datetime import datetime, timedelta
+from datetime import datetime
 
-from extensions import db
-from models import User, Pig, Race, Participant, Bet, CoursePlan
+from models import User, Race, Participant, Bet
 from data import BET_TYPES, WEEKLY_RACE_QUOTA, WEEKLY_BACON_TICKETS
 from helpers import ensure_next_race, get_user_active_pigs, apply_row_lock
 from services.pig_service import calculate_pig_power, get_weight_profile
 from services.race_service import (
-    count_pig_weekly_course_commitments, build_course_schedule,
-    populate_race_participants, get_user_weekly_bet_count,
-    normalize_bet_type, parse_selection_ids, serialize_selection_ids,
-    format_bet_label, calculate_bet_odds,
+    RacePlanningError, build_course_schedule, calculate_bet_odds,
+    count_pig_weekly_course_commitments, format_bet_label,
+    get_user_weekly_bet_count, normalize_bet_type, parse_selection_ids,
+    plan_pig_for_race, serialize_selection_ids,
 )
 
 race_bp = Blueprint('race', __name__)
@@ -68,60 +67,19 @@ def plan_course():
 
     pig_id = request.form.get('pig_id', type=int)
     scheduled_at_raw = (request.form.get('scheduled_at') or '').strip()
-    pig = Pig.query.filter_by(id=pig_id, user_id=user.id, is_alive=True).first()
-    if not pig:
-        flash("Cochon introuvable pour cette planification.", "error")
-        return redirect(url_for('race.courses'))
-
-    try:
-        scheduled_at = datetime.fromisoformat(scheduled_at_raw).replace(microsecond=0)
-    except ValueError:
-        flash("Creneau de course invalide.", "error")
-        return redirect(url_for('race.courses'))
-
-    if scheduled_at <= datetime.now() + timedelta(seconds=30):
-        flash("Cette course est trop proche pour modifier les inscriptions.", "warning")
-        return redirect(url_for('race.courses'))
-
-    open_race = Race.query.filter_by(scheduled_at=scheduled_at, status='open').first()
-    if open_race and Bet.query.filter_by(race_id=open_race.id).count() > 0:
-        flash("Cette course est deja verrouillee par des paris. Plus de modification possible.", "warning")
-        return redirect(url_for('race.courses'))
-    if open_race and (pig.is_injured or pig.energy <= 20 or pig.hunger <= 20):
-        flash(f"{pig.name} n'est pas en etat de rejoindre la course ouverte du moment.", "warning")
-        return redirect(url_for('race.courses'))
-
-    already_participant = False
-    if open_race:
-        already_participant = Participant.query.filter_by(race_id=open_race.id, pig_id=pig.id).first() is not None
-
-    existing_plan = CoursePlan.query.filter_by(user_id=user.id, pig_id=pig.id, scheduled_at=scheduled_at).first()
-    if existing_plan:
-        db.session.delete(existing_plan)
-        if open_race:
-            populate_race_participants(open_race, respect_course_plans=True, allow_rebuild_if_bets=False, commit=False)
-        db.session.commit()
-        flash(f"📅 {pig.name} est retire du planning du {scheduled_at.strftime('%d/%m %H:%M')}.", "success")
-        return redirect(url_for('race.courses'))
-
-    if already_participant:
-        flash(f"{pig.name} est deja partant sur cette course ouverte.", "warning")
-        return redirect(url_for('race.courses'))
-
-    if count_pig_weekly_course_commitments(pig.id, scheduled_at) >= WEEKLY_RACE_QUOTA:
-        flash(f"{pig.name} a deja atteint son quota hebdomadaire de {WEEKLY_RACE_QUOTA} courses.", "warning")
-        return redirect(url_for('race.courses'))
-
     strategy = request.form.get('strategy', 50, type=int)
 
-    db.session.add(CoursePlan(user_id=user.id, pig_id=pig.id, scheduled_at=scheduled_at, strategy=strategy))
-    db.session.flush()
+    try:
+        action = plan_pig_for_race(user.id, pig_id, scheduled_at_raw, strategy)
+    except RacePlanningError as exc:
+        category = 'error' if 'invalide' in str(exc).lower() or 'introuvable' in str(exc).lower() else 'warning'
+        flash(str(exc), category)
+        return redirect(url_for('race.courses'))
 
-    if open_race:
-        populate_race_participants(open_race, respect_course_plans=True, allow_rebuild_if_bets=False, commit=False)
-
-    db.session.commit()
-    flash(f"📅 {pig.name} est maintenant planifie pour la course du {scheduled_at.strftime('%d/%m %H:%M')}.", "success")
+    if action.action == 'removed':
+        flash(f"📅 {action.pig_name} est retire du planning du {action.scheduled_at.strftime('%d/%m %H:%M')}.", "success")
+    else:
+        flash(f"📅 {action.pig_name} est maintenant planifie pour la course du {action.scheduled_at.strftime('%d/%m %H:%M')}.", "success")
     return redirect(url_for('race.courses'))
 
 

--- a/services/game_settings_service.py
+++ b/services/game_settings_service.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+
+from helpers import get_config
+
+
+@dataclass(frozen=True)
+class GameSettings:
+    race_hour: int
+    race_minute: int
+    market_day: int
+    market_hour: int
+    market_minute: int
+    market_duration: int
+    min_real_participants: int
+    empty_race_mode: str
+
+    @classmethod
+    def load(cls):
+        return cls(
+            race_hour=_get_int_config('race_hour', 14),
+            race_minute=_get_int_config('race_minute', 0),
+            market_day=_get_int_config('market_day', 4),
+            market_hour=_get_int_config('market_hour', 13),
+            market_minute=_get_int_config('market_minute', 45),
+            market_duration=_get_int_config('market_duration', 120),
+            min_real_participants=_get_int_config('min_real_participants', 2),
+            empty_race_mode=get_config('empty_race_mode', 'fill') or 'fill',
+        )
+
+
+def _get_int_config(key, default):
+    raw_value = get_config(key, str(default))
+    try:
+        return int(raw_value)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def get_game_settings():
+    return GameSettings.load()

--- a/services/market_service.py
+++ b/services/market_service.py
@@ -12,7 +12,8 @@ from data import (
 from extensions import db
 from models import Auction, BalanceTransaction, GrainMarket, Pig, User
 
-from helpers import apply_row_lock, get_config
+from helpers import apply_row_lock
+from services.game_settings_service import get_game_settings
 from services.finance_service import credit_user_balance
 from services.pig_service import build_unique_pig_name, generate_weight_kg_for_profile
 
@@ -28,35 +29,28 @@ def get_prix_moyen_groin():
 
 
 def get_next_market_time():
-    market_day = int(get_config('market_day', '4'))
-    market_hour = int(get_config('market_hour', '13'))
-    market_minute = int(get_config('market_minute', '45'))
+    settings = get_game_settings()
     now = datetime.now()
-    days_ahead = market_day - now.weekday()
-    if days_ahead < 0 or (days_ahead == 0 and now.hour * 60 + now.minute >= market_hour * 60 + market_minute + int(get_config('market_duration', '120'))):
+    days_ahead = settings.market_day - now.weekday()
+    if days_ahead < 0 or (days_ahead == 0 and now.hour * 60 + now.minute >= settings.market_hour * 60 + settings.market_minute + settings.market_duration):
         days_ahead += 7
-    return now.replace(hour=market_hour, minute=market_minute, second=0, microsecond=0) + timedelta(days=days_ahead)
+    return now.replace(hour=settings.market_hour, minute=settings.market_minute, second=0, microsecond=0) + timedelta(days=days_ahead)
 
 
 def is_market_open():
-    market_day = int(get_config('market_day', '4'))
-    market_hour = int(get_config('market_hour', '13'))
-    market_minute = int(get_config('market_minute', '45'))
-    duration = int(get_config('market_duration', '120'))
+    settings = get_game_settings()
     now = datetime.now()
-    if now.weekday() != market_day:
+    if now.weekday() != settings.market_day:
         return False
-    market_start = now.replace(hour=market_hour, minute=market_minute, second=0, microsecond=0)
-    return market_start <= now <= market_start + timedelta(minutes=duration)
+    market_start = now.replace(hour=settings.market_hour, minute=settings.market_minute, second=0, microsecond=0)
+    return market_start <= now <= market_start + timedelta(minutes=settings.market_duration)
 
 
 def get_market_close_time():
-    market_hour = int(get_config('market_hour', '13'))
-    market_minute = int(get_config('market_minute', '45'))
-    duration = int(get_config('market_duration', '120'))
+    settings = get_game_settings()
     now = datetime.now()
-    market_start = now.replace(hour=market_hour, minute=market_minute, second=0, microsecond=0)
-    return market_start + timedelta(minutes=duration)
+    market_start = now.replace(hour=settings.market_hour, minute=settings.market_minute, second=0, microsecond=0)
+    return market_start + timedelta(minutes=settings.market_duration)
 
 
 def generate_auction_pig():

--- a/services/pig_service.py
+++ b/services/pig_service.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime
 import math
 import random
@@ -14,6 +15,30 @@ from extensions import db
 from models import Auction, Pig
 
 from helpers import calculate_weekend_truce_hours
+
+
+@dataclass(frozen=True)
+class PigHeritageSnapshot:
+    races_won: int
+    level: int
+    rarity: str
+    lineage_boost: float
+
+    @classmethod
+    def from_source(cls, pig):
+        if isinstance(pig, dict):
+            return cls(
+                races_won=int(pig.get('races_won') or 0),
+                level=max(1, int(pig.get('level') or 1)),
+                rarity=str(pig.get('rarity') or 'commun'),
+                lineage_boost=float(pig.get('lineage_boost') or 0.0),
+            )
+        return cls(
+            races_won=int(getattr(pig, 'races_won', 0) or 0),
+            level=max(1, int(getattr(pig, 'level', 1) or 1)),
+            rarity=str(getattr(pig, 'rarity', 'commun') or 'commun'),
+            lineage_boost=float(getattr(pig, 'lineage_boost', 0.0) or 0.0),
+        )
 
 
 def get_freshness_bonus(pig):
@@ -247,10 +272,9 @@ def get_lineage_label(pig):
 
 
 def get_pig_heritage_value(pig):
-    wins = pig.races_won or 0
-    level = pig.level or 1
-    rarity_bonus = {'commun': 0.0, 'rare': 0.5, 'epique': 1.0, 'legendaire': 2.0}.get(pig.rarity or 'commun', 0.0)
-    return round((wins * 0.6) + max(0, level - 1) * 0.08 + (pig.lineage_boost or 0.0) + rarity_bonus, 2)
+    heritage = PigHeritageSnapshot.from_source(pig)
+    rarity_bonus = {'commun': 0.0, 'rare': 0.5, 'epique': 1.0, 'legendaire': 2.0}.get(heritage.rarity, 0.0)
+    return round((heritage.races_won * 0.6) + max(0, heritage.level - 1) * 0.08 + heritage.lineage_boost + rarity_bonus, 2)
 
 
 def can_retire_into_heritage(pig):

--- a/services/race_service.py
+++ b/services/race_service.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 import math
 import random
@@ -13,9 +14,61 @@ from extensions import db
 from models import Bet, CoursePlan, Participant, Pig, Race, User
 from race_engine import CourseManager
 
-from helpers import apply_row_lock, get_config
+from helpers import apply_row_lock
 from services.finance_service import credit_user_balance
+from services.game_settings_service import get_game_settings
 from services.pig_service import calculate_pig_power, get_weight_profile, update_pig_state
+
+
+class RacePlanningError(Exception):
+    """Erreur métier levée pendant la planification d'une course."""
+
+
+class PigNotFoundError(RacePlanningError):
+    pass
+
+
+class InvalidRaceSlotError(RacePlanningError):
+    pass
+
+
+class RaceLockedError(RacePlanningError):
+    pass
+
+
+class PigNotRaceReadyError(RacePlanningError):
+    pass
+
+
+class RaceAlreadyJoinedError(RacePlanningError):
+    pass
+
+
+class WeeklyQuotaReachedError(RacePlanningError):
+    pass
+
+
+@dataclass(frozen=True)
+class BetParticipantSnapshot:
+    id: int
+    win_probability: float
+
+    @classmethod
+    def from_source(cls, source):
+        if isinstance(source, dict):
+            source_id = source.get('id', 0)
+            win_probability = source.get('win_probability', 0.0)
+        else:
+            source_id = getattr(source, 'id', 0)
+            win_probability = getattr(source, 'win_probability', 0.0)
+        return cls(id=int(source_id), win_probability=float(win_probability or 0.0))
+
+
+@dataclass(frozen=True)
+class PlannedRaceAction:
+    action: str
+    pig_name: str
+    scheduled_at: datetime
 
 
 def normalize_bet_type(bet_type):
@@ -44,8 +97,13 @@ def format_bet_label(participants):
     return ' -> '.join(participant.name for participant in participants)
 
 
+def _build_bet_participant_snapshots(participants_by_id):
+    return {participant_id: BetParticipantSnapshot.from_source(participant) for participant_id, participant in participants_by_id.items()}
+
+
 def calculate_ordered_finish_probability(participants_by_id, ordered_ids):
-    remaining_probabilities = {participant_id: max(participant.win_probability or 0.0, 0.0) for participant_id, participant in participants_by_id.items()}
+    participant_snapshots = _build_bet_participant_snapshots(participants_by_id)
+    remaining_probabilities = {participant_id: max(participant.win_probability, 0.0) for participant_id, participant in participant_snapshots.items()}
     remaining_total = sum(remaining_probabilities.values())
     if remaining_total <= 0:
         return 0.0
@@ -135,16 +193,67 @@ def get_course_theme(slot_time):
 
 
 def get_next_race_time():
-    race_hour = int(get_config('race_hour', '14'))
-    race_minute = int(get_config('race_minute', '00'))
+    settings = get_game_settings()
     now = datetime.now()
-    today_race = now.replace(hour=race_hour, minute=race_minute, second=0, microsecond=0)
+    today_race = now.replace(hour=settings.race_hour, minute=settings.race_minute, second=0, microsecond=0)
     return today_race + timedelta(days=1) if now >= today_race else today_race
 
 
 def get_upcoming_course_slots(days=30):
     first_slot = get_next_race_time()
     return [first_slot + timedelta(days=offset) for offset in range(days)]
+
+
+def _get_open_race_for_slot(scheduled_at):
+    return Race.query.filter_by(scheduled_at=scheduled_at, status='open').first()
+
+
+def plan_pig_for_race(user_id, pig_id, scheduled_at_raw, strategy):
+    pig = Pig.query.filter_by(id=pig_id, user_id=user_id, is_alive=True).first()
+    if not pig:
+        raise PigNotFoundError("Cochon introuvable pour cette planification.")
+
+    try:
+        scheduled_at = datetime.fromisoformat((scheduled_at_raw or '').strip()).replace(microsecond=0)
+    except ValueError as exc:
+        raise InvalidRaceSlotError("Creneau de course invalide.") from exc
+
+    if scheduled_at <= datetime.now() + timedelta(seconds=30):
+        raise RaceLockedError("Cette course est trop proche pour modifier les inscriptions.")
+
+    open_race = _get_open_race_for_slot(scheduled_at)
+    if open_race and Bet.query.filter_by(race_id=open_race.id).count() > 0:
+        raise RaceLockedError("Cette course est deja verrouillee par des paris. Plus de modification possible.")
+
+    if open_race and (pig.is_injured or pig.energy <= 20 or pig.hunger <= 20):
+        raise PigNotRaceReadyError(f"{pig.name} n'est pas en etat de rejoindre la course ouverte du moment.")
+
+    already_participant = False
+    if open_race:
+        already_participant = Participant.query.filter_by(race_id=open_race.id, pig_id=pig.id).first() is not None
+
+    existing_plan = CoursePlan.query.filter_by(user_id=user_id, pig_id=pig.id, scheduled_at=scheduled_at).first()
+    if existing_plan:
+        db.session.delete(existing_plan)
+        if open_race:
+            populate_race_participants(open_race, respect_course_plans=True, allow_rebuild_if_bets=False, commit=False)
+        db.session.commit()
+        return PlannedRaceAction(action='removed', pig_name=pig.name, scheduled_at=scheduled_at)
+
+    if already_participant:
+        raise RaceAlreadyJoinedError(f"{pig.name} est deja partant sur cette course ouverte.")
+
+    if count_pig_weekly_course_commitments(pig.id, scheduled_at) >= WEEKLY_RACE_QUOTA:
+        raise WeeklyQuotaReachedError(f"{pig.name} a deja atteint son quota hebdomadaire de {WEEKLY_RACE_QUOTA} courses.")
+
+    db.session.add(CoursePlan(user_id=user_id, pig_id=pig.id, scheduled_at=scheduled_at, strategy=int(strategy)))
+    db.session.flush()
+
+    if open_race:
+        populate_race_participants(open_race, respect_course_plans=True, allow_rebuild_if_bets=False, commit=False)
+
+    db.session.commit()
+    return PlannedRaceAction(action='planned', pig_name=pig.name, scheduled_at=scheduled_at)
 
 
 def get_race_ready_pigs():


### PR DESCRIPTION
### Motivation

- Simplifier les routes en sortant la logique métier de planification des courses du contrôleur pour rendre le code plus testable et réduire les responsabilités de la couche HTTP.
- Éviter les accès ORM accidentels pendant les calculs (N+1) en utilisant des vues légères (`dataclass`) pour les calculs critiques (cotes, héritage).
- Centraliser la lecture/typage des configurations de jeu pour supprimer les multiples `get_config(...)/int(...)` dispersés et gérer les conversions de manière robuste.

### Description

- Extrait la logique de planification de `routes/race.py` vers `services/race_service.py` et ajoute des exceptions métier (`RacePlanningError`, `PigNotFoundError`, `RaceLockedError`, etc.) ainsi qu'un type de retour structuré `PlannedRaceAction` pour indiquer `planned` ou `removed`.
- Introduit `BetParticipantSnapshot` dans `services/race_service.py` pour découpler `calculate_bet_odds` / `calculate_ordered_finish_probability` des objets ORM, et applique la même approche pour l'héritage avec `PigHeritageSnapshot` dans `services/pig_service.py`.
- Ajout de `services/game_settings_service.py` contenant la dataclass `GameSettings` et la fonction `get_game_settings()` pour charger/convertir proprement les paramètres de configuration typés.
- Répercuté l'utilisation de `GameSettings` dans `services/market_service.py`, `routes/market.py` et `routes/admin.py`, et simplifié `routes/race.py` pour déléguer la planification à `plan_pig_for_race` et ne gérer que les messages Flash.

### Testing

- `python -m py_compile routes/race.py routes/market.py routes/admin.py services/race_service.py services/pig_service.py services/market_service.py services/game_settings_service.py` — compilation réussie pour tous les modules modifiés.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bec8931bb88323a7f1146597a8588b)