### PR TITLE
Extract weekend truce time utilities into utils/time_utils.py

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,8 +1,7 @@
-from datetime import datetime, timedelta, time
+from datetime import datetime
 from sqlalchemy import func, or_, update
 import random
 import math
-from zoneinfo import ZoneInfo
 
 from extensions import db
 from models import (
@@ -28,6 +27,7 @@ from data import (
     BOURSE_GRAIN_LAYOUT, CEREALS,
 )
 from race_engine import CourseManager
+from utils.time_utils import calculate_weekend_truce_hours
 
 
 # ─── HELPERS CONFIG ─────────────────────────────────────────────────────────
@@ -63,74 +63,6 @@ def init_default_config():
 
 # ─── HELPERS COCHON ─────────────────────────────────────────────────────────
  
-PARIS_TZ = ZoneInfo('Europe/Paris')
-WEEKEND_TRUCE_START = time(18, 0)
-WEEKEND_TRUCE_END = time(8, 0)
-
-def get_paris_now():
-    return datetime.now(PARIS_TZ)
-
-def to_paris_time(dt):
-    if dt is None:
-        return None
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=ZoneInfo('UTC')).astimezone(PARIS_TZ)
-    return dt.astimezone(PARIS_TZ)
-
-def is_weekend_truce_active(moment=None):
-    local_moment = to_paris_time(moment or datetime.utcnow())
-    weekday = local_moment.weekday()
-    local_time = local_moment.time()
-    if weekday == 4 and local_time >= WEEKEND_TRUCE_START:
-        return True
-    if weekday in (5, 6):
-        return True
-    if weekday == 0 and local_time < WEEKEND_TRUCE_END:
-        return True
-    return False
-
-def _next_weekend_truce_start(after_local):
-    candidate_day = after_local.date()
-    days_until_friday = (4 - after_local.weekday()) % 7
-    candidate_day = candidate_day + timedelta(days=days_until_friday)
-    candidate_start = datetime.combine(candidate_day, WEEKEND_TRUCE_START, tzinfo=PARIS_TZ)
-    if candidate_start <= after_local:
-        candidate_start += timedelta(days=7)
-    return candidate_start
-
-def calculate_weekend_truce_hours(start_dt, end_dt):
-    if not start_dt or not end_dt or end_dt <= start_dt:
-        return 0.0
-    start_local = to_paris_time(start_dt)
-    end_local = to_paris_time(end_dt)
-    overlap_seconds = 0.0
-
-    if is_weekend_truce_active(start_local):
-        weekday = start_local.weekday()
-        if weekday == 4:
-            truce_start = datetime.combine(start_local.date(), WEEKEND_TRUCE_START, tzinfo=PARIS_TZ)
-        elif weekday == 5:
-            truce_start = datetime.combine(start_local.date() - timedelta(days=1), WEEKEND_TRUCE_START, tzinfo=PARIS_TZ)
-        elif weekday == 6:
-            truce_start = datetime.combine(start_local.date() - timedelta(days=2), WEEKEND_TRUCE_START, tzinfo=PARIS_TZ)
-        else:
-            truce_start = datetime.combine(start_local.date() - timedelta(days=3), WEEKEND_TRUCE_START, tzinfo=PARIS_TZ)
-        truce_end = truce_start + timedelta(days=2, hours=14)
-        overlap_seconds += (min(end_local, truce_end) - start_local).total_seconds()
-        cursor = truce_end
-    else:
-        cursor = start_local
-
-    while cursor < end_local:
-        truce_start = _next_weekend_truce_start(cursor)
-        if truce_start >= end_local:
-            break
-        truce_end = truce_start + timedelta(days=2, hours=14)
-        overlap_seconds += (min(end_local, truce_end) - truce_start).total_seconds()
-        cursor = truce_end
-
-    return max(0.0, overlap_seconds / 3600.0)
-
 def get_freshness_bonus(pig):
     if not pig or not pig.last_fed_at:
         return {'active': False, 'multiplier': 1.0, 'bonus_percent': 0.0, 'hours_remaining': 0.0}

--- a/models.py
+++ b/models.py
@@ -295,7 +295,7 @@ class Pig(db.Model):
     def update_vitals(self):
         """Décroissance Tamagotchi en fonction du temps écoulé.
         Appelé avant chaque interaction pour synchroniser l'état."""
-        from helpers import calculate_weekend_truce_hours
+        from utils.time_utils import calculate_weekend_truce_hours
         from data import DEFAULT_PIG_WEIGHT_KG
 
         now = datetime.utcnow()

--- a/routes/pig.py
+++ b/routes/pig.py
@@ -12,9 +12,10 @@ from data import (
 from helpers import (
     get_user_active_pigs,
     get_cooldown_remaining, format_duration_short, get_seconds_until,
-    is_weekend_truce_active,
     get_cereals_dict, get_trainings_dict, get_school_lessons_dict,
 )
+from utils.time_utils import is_weekend_truce_active
+
 from services.finance_service import (
     maybe_grant_emergency_relief, reserve_pig_challenge_slot, release_pig_challenge_slot,
 )

--- a/services/pig_service.py
+++ b/services/pig_service.py
@@ -14,7 +14,7 @@ from data import (
 from extensions import db
 from models import Auction, Pig
 
-from helpers import calculate_weekend_truce_hours
+from utils.time_utils import calculate_weekend_truce_hours
 
 
 @dataclass(frozen=True)

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,0 +1,86 @@
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+PARIS_TZ = ZoneInfo('Europe/Paris')
+WEEKEND_TRUCE_START = time(18, 0)
+WEEKEND_TRUCE_END = time(8, 0)
+WEEKEND_TRUCE_DURATION = timedelta(days=2, hours=14)
+
+
+def get_paris_now():
+    return datetime.now(PARIS_TZ)
+
+
+def to_paris_time(dt):
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=ZoneInfo('UTC')).astimezone(PARIS_TZ)
+    return dt.astimezone(PARIS_TZ)
+
+
+def is_weekend_truce_active(moment=None):
+    local_moment = to_paris_time(moment or datetime.utcnow())
+    weekday = local_moment.weekday()
+    local_time = local_moment.time()
+    if weekday == 4 and local_time >= WEEKEND_TRUCE_START:
+        return True
+    if weekday in (5, 6):
+        return True
+    if weekday == 0 and local_time < WEEKEND_TRUCE_END:
+        return True
+    return False
+
+
+def _next_weekend_truce_start(after_local):
+    candidate_day = after_local.date()
+    days_until_friday = (4 - after_local.weekday()) % 7
+    candidate_day = candidate_day + timedelta(days=days_until_friday)
+    candidate_start = datetime.combine(candidate_day, WEEKEND_TRUCE_START, tzinfo=PARIS_TZ)
+    if candidate_start <= after_local:
+        candidate_start += timedelta(days=7)
+    return candidate_start
+
+
+def _get_current_truce_window_start(local_moment):
+    weekday = local_moment.weekday()
+    if weekday == 4:
+        delta_days = 0
+    elif weekday == 5:
+        delta_days = 1
+    elif weekday == 6:
+        delta_days = 2
+    else:
+        delta_days = 3
+    return datetime.combine(
+        local_moment.date() - timedelta(days=delta_days),
+        WEEKEND_TRUCE_START,
+        tzinfo=PARIS_TZ,
+    )
+
+
+def calculate_weekend_truce_hours(start_dt, end_dt):
+    if not start_dt or not end_dt or end_dt <= start_dt:
+        return 0.0
+
+    start_local = to_paris_time(start_dt)
+    end_local = to_paris_time(end_dt)
+    overlap_seconds = 0.0
+
+    if is_weekend_truce_active(start_local):
+        truce_start = _get_current_truce_window_start(start_local)
+        truce_end = truce_start + WEEKEND_TRUCE_DURATION
+        overlap_seconds += (min(end_local, truce_end) - start_local).total_seconds()
+        cursor = truce_end
+    else:
+        cursor = start_local
+
+    while cursor < end_local:
+        truce_start = _next_weekend_truce_start(cursor)
+        if truce_start >= end_local:
+            break
+        truce_end = truce_start + WEEKEND_TRUCE_DURATION
+        overlap_seconds += (min(end_local, truce_end) - truce_start).total_seconds()
+        cursor = truce_end
+
+    return max(0.0, overlap_seconds / 3600.0)


### PR DESCRIPTION
### Motivation
- Centralize Paris timezone and weekend-truce logic so models and services can share it without creating cross-dependencies or duplicating code. 
- Isolate complex time calculations (truce detection and overlap hours) away from business helpers to reduce coupling and make intent explicit.

### Description
- Add `utils/time_utils.py` providing `get_paris_now`, `to_paris_time`, `is_weekend_truce_active` and `calculate_weekend_truce_hours` and internal helpers for truce window computation. 
- Remove the duplicate timezone/truce definitions from `helpers.py` and import `calculate_weekend_truce_hours` from `utils.time_utils`. 
- Update `models.py` and `services/pig_service.py` to import `calculate_weekend_truce_hours` from `utils.time_utils`. 
- Update `routes/pig.py` to import `is_weekend_truce_active` from `utils.time_utils` for UI usage.

### Testing
- Ran syntax/bytecode checks with `python -m compileall models.py helpers.py services routes utils` which completed successfully. 
- Recompiled relevant modules with `python -m compileall routes/pig.py services/pig_service.py utils/time_utils.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed3d8b8a083239520bda449191f8d)