### PR TITLE
Introduit la Fraîcheur des cochons et un Palmarès mémoriel

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import os
 
 from extensions import db
 from models import (
-    GameConfig, User, Pig, BalanceTransaction, GrainMarket,
+    GameConfig, User, Pig, BalanceTransaction, GrainMarket, Trophy,
     CerealItem, TrainingItem, SchoolLessonItem,
 )
 from data import PIG_ORIGINS, CEREALS, TRAININGS, SCHOOL_LESSONS
@@ -73,6 +73,8 @@ def migrate_db():
         ('pig', 'last_fed_at', 'DATETIME'),
         ('pig', 'school_sessions_completed', 'INTEGER DEFAULT 0'),
         ('pig', 'weight_kg', 'FLOAT DEFAULT 112.0'),
+        ('pig', 'freshness', 'FLOAT DEFAULT 100.0'),
+        ('pig', 'ever_bad_state', 'BOOLEAN DEFAULT 0'),
         ('pig', 'is_injured', 'BOOLEAN DEFAULT 0'),
         ('pig', 'injury_risk', 'FLOAT DEFAULT 10.0'),
         ('pig', 'vet_deadline', 'DATETIME'),
@@ -98,14 +100,34 @@ def migrate_db():
         ('bet', 'bet_type', 'VARCHAR(20) DEFAULT "win"'),
         ('bet', 'selection_order', 'VARCHAR(240)'),
         ('user', 'last_daily_reward_at', 'DATETIME'),
+        ('trophy', 'pig_name', 'VARCHAR(80)'),
+    ]
+    table_migrations = [
+        """CREATE TABLE IF NOT EXISTS trophy (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL,
+            code VARCHAR(50) NOT NULL,
+            label VARCHAR(80) NOT NULL,
+            emoji VARCHAR(10) NOT NULL DEFAULT '🏆',
+            description VARCHAR(255) NOT NULL,
+            pig_name VARCHAR(80),
+            earned_at DATETIME
+        )""",
     ]
     index_migrations = [
+        'CREATE UNIQUE INDEX IF NOT EXISTS ux_trophy_user_code ON trophy(user_id, code)',
         'CREATE UNIQUE INDEX IF NOT EXISTS ux_bet_user_race ON bet(user_id, race_id)',
         'CREATE INDEX IF NOT EXISTS ix_auction_status_ends_at ON auction(status, ends_at)',
         'CREATE INDEX IF NOT EXISTS ix_race_status_scheduled_at ON race(status, scheduled_at)',
         'CREATE INDEX IF NOT EXISTS ix_pig_vet_deadline ON pig(is_injured, is_alive, vet_deadline)',
     ]
     with db.engine.connect() as conn:
+        for statement in table_migrations:
+            try:
+                conn.execute(db.text(statement))
+                conn.commit()
+            except Exception:
+                pass
         for table, col, col_type in migrations:
             try:
                 conn.execute(db.text(f"SELECT {col} FROM {table} LIMIT 1"))

--- a/helpers.py
+++ b/helpers.py
@@ -64,16 +64,13 @@ def init_default_config():
 # ─── HELPERS COCHON ─────────────────────────────────────────────────────────
  
 def get_freshness_bonus(pig):
-    if not pig or not pig.last_fed_at:
-        return {'active': False, 'multiplier': 1.0, 'bonus_percent': 0.0, 'hours_remaining': 0.0}
-    elapsed_hours = max(0.0, (datetime.utcnow() - pig.last_fed_at).total_seconds() / 3600.0)
-    active = elapsed_hours < FRESHNESS_BONUS_HOURS
-    remaining = max(0.0, FRESHNESS_BONUS_HOURS - elapsed_hours)
+    freshness_value = max(0.0, min(100.0, float(getattr(pig, 'freshness', 100.0) or 100.0))) if pig else 100.0
     return {
-        'active': active,
-        'multiplier': round(1.0 + FRESHNESS_MORAL_BONUS, 3) if active else 1.0,
-        'bonus_percent': round(FRESHNESS_MORAL_BONUS * 100, 1) if active else 0.0,
-        'hours_remaining': round(remaining, 2),
+        'active': freshness_value >= 95.0,
+        'multiplier': 1.0,
+        'bonus_percent': 0.0,
+        'hours_remaining': 0.0,
+        'value': round(freshness_value, 1),
     }
 
 def get_pig_performance_flags(pig):
@@ -1358,7 +1355,8 @@ def run_race_if_needed():
             continue
 
         participants_by_id = {participant.id: participant for participant in participants}
-        
+        pig_start_freshness = {}
+
         # New Tactical Simulation
         # Fetch actual pig stats for simulation
         pigs_for_sim = []
@@ -1367,6 +1365,7 @@ def run_race_if_needed():
                 pig = Pig.query.get(p.pig_id)
                 if pig:
                     pig.strategy = p.strategy # Sync current player strategy
+                    pig_start_freshness[p.pig_id] = float(pig.freshness or 100.0)
                     pigs_for_sim.append(pig)
                 else:
                     # Mock NPC pig stats based on odds
@@ -1457,6 +1456,16 @@ def run_race_if_needed():
                 pig.xp += xp_gained
                 if p.finish_position == 1:
                     pig.races_won += 1
+                    if (pig_start_freshness.get(pig.id, 100.0) < 80.0) and owner:
+                        from models import Trophy
+                        Trophy.award(
+                            user_id=owner.id,
+                            code='comeback_win',
+                            label='Retour Gagnant',
+                            emoji='🔁',
+                            description="Gagner une course en partant avec moins de 80% de fraicheur.",
+                            pig_name=pig.name,
+                        )
                     pig.vitesse = min(100, pig.vitesse + random.uniform(0.5, 1.5))
                     pig.endurance = min(100, pig.endurance + random.uniform(0.5, 1.5))
                     pig.moral = min(100, pig.moral + 2)
@@ -1468,6 +1477,7 @@ def run_race_if_needed():
                 pig.energy = max(0, pig.energy - 15)
                 pig.hunger = max(0, pig.hunger - 10)
                 pig.adjust_weight(-0.3)
+                pig.mark_bad_state_if_needed()
                 pig.last_updated = datetime.utcnow()
                 pig.check_level_up()
 

--- a/models.py
+++ b/models.py
@@ -25,6 +25,7 @@ class User(db.Model):
     bets = db.relationship('Bet', backref='user', lazy=True)
     balance_transactions = db.relationship('BalanceTransaction', backref='user', lazy=True)
     course_plans = db.relationship('CoursePlan', backref='user', lazy=True)
+    trophies = db.relationship('Trophy', backref='user', lazy=True, cascade='all, delete-orphan')
 
     # ── Méthodes métier ─────────────────────────────────────────────────
 
@@ -104,6 +105,8 @@ class Pig(db.Model):
     hunger = db.Column(db.Float, default=60.0)
     happiness = db.Column(db.Float, default=70.0)
     weight_kg = db.Column(db.Float, default=112.0)
+    freshness = db.Column(db.Float, default=100.0)
+    ever_bad_state = db.Column(db.Boolean, default=False)
 
     # Progression
     xp = db.Column(db.Integer, default=0)
@@ -207,6 +210,38 @@ class Pig(db.Model):
             self.level += 1
             self.happiness = min(100, self.happiness + 10)
 
+    def reset_freshness(self):
+        """Remet la fraicheur a fond apres une interaction positive."""
+        self.freshness = 100.0
+
+    def mark_bad_state_if_needed(self):
+        """Memorise si le cochon est deja passe par un mauvais etat."""
+        if (self.hunger or 0) < 20 or (self.energy or 0) < 20:
+            self.ever_bad_state = True
+
+    def maybe_award_memorial_trophies(self):
+        """Attribue les trophees memoriels lies a la fin de carriere."""
+        if not self.owner:
+            return
+        if self.created_at and (datetime.utcnow() - self.created_at).days >= 90:
+            Trophy.award(
+                user_id=self.owner.id,
+                code='office_pillar',
+                label='Le Pilier de Bureau',
+                emoji='🪑',
+                description='Un cochon a tenu plus de 3 mois reels avant de quitter la piste.',
+                pig_name=self.name,
+            )
+        if (self.max_races and self.races_entered >= self.max_races and not self.ever_bad_state):
+            Trophy.award(
+                user_id=self.owner.id,
+                code='golden_retirement',
+                label='Retraite Doree',
+                emoji='☕',
+                description="Atteindre la limite de courses sans jamais tomber en mauvais etat.",
+                pig_name=self.name,
+            )
+
     def feed(self, cereal: dict):
         """Nourrir le cochon avec une céréale (dict issu de data.CEREALS).
         Met à jour faim, énergie, poids, stats et timestamps."""
@@ -216,6 +251,8 @@ class Pig(db.Model):
         self.apply_stat_boosts(cereal.get('stats', {}))
         self.last_fed_at = datetime.utcnow()
         self.last_updated = self.last_fed_at
+        self.reset_freshness()
+        self.mark_bad_state_if_needed()
 
     def train(self, training: dict):
         """Entraîner le cochon (dict issu de data.TRAININGS).
@@ -226,7 +263,9 @@ class Pig(db.Model):
         if 'happiness_bonus' in training:
             self.happiness = min(100, self.happiness + training['happiness_bonus'])
         self.apply_stat_boosts(training.get('stats', {}))
+        self.reset_freshness()
         self.last_updated = datetime.utcnow()
+        self.mark_bad_state_if_needed()
 
     def study(self, lesson: dict, correct: bool) -> str:
         """Suivre un cours (dict issu de data.SCHOOL_LESSONS).
@@ -246,7 +285,9 @@ class Pig(db.Model):
             self.happiness = max(0, self.happiness - lesson.get('wrong_happiness_penalty', 0))
             category = 'warning'
 
+        self.reset_freshness()
         self.last_updated = datetime.utcnow()
+        self.mark_bad_state_if_needed()
         self.check_level_up()
         return category
 
@@ -274,6 +315,7 @@ class Pig(db.Model):
         self.charcuterie_emoji = charcuterie['emoji']
         self.epitaph = epitaph_template.format(name=self.name, wins=self.races_won)
         self.challenge_mort_wager = 0
+        self.maybe_award_memorial_trophies()
 
     def retire(self):
         """Retire le cochon pour vieillesse (charcuterie premium)."""
@@ -291,6 +333,7 @@ class Pig(db.Model):
             f"Un cochon bien vieilli fait le meilleur jambon."
         )
         self.challenge_mort_wager = 0
+        self.maybe_award_memorial_trophies()
 
     def update_vitals(self):
         """Décroissance Tamagotchi en fonction du temps écoulé.
@@ -306,11 +349,16 @@ class Pig(db.Model):
         if elapsed_hours < 0.01:
             return
         truce_hours = calculate_weekend_truce_hours(self.last_updated, now)
-        hours = min(max(0.0, elapsed_hours - truce_hours), 24)
-        if hours < 0.01:
+        effective_hours = max(0.0, elapsed_hours - truce_hours)
+        hours = min(effective_hours, 24)
+        if effective_hours < 0.01:
             self.last_updated = now
             db.session.commit()
             return
+
+        freshness_decay_hours = max(0.0, effective_hours - 48.0)
+        if freshness_decay_hours > 0:
+            self.freshness = max(0.0, (self.freshness or 100.0) - (freshness_decay_hours * (5.0 / 24.0)))
 
         # Faim décroît avec le temps
         self.hunger = max(0, self.hunger - hours * 2)
@@ -338,8 +386,34 @@ class Pig(db.Model):
         elif self.energy > 80 and self.hunger < 60:
             self.weight_kg = round(min(190.0, max(75.0, current_weight - hours * 0.08)), 1)
 
+        self.mark_bad_state_if_needed()
         self.last_updated = now
         db.session.commit()
+
+
+
+class Trophy(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False, index=True)
+    code = db.Column(db.String(50), nullable=False)
+    label = db.Column(db.String(80), nullable=False)
+    emoji = db.Column(db.String(10), nullable=False, default='🏆')
+    description = db.Column(db.String(255), nullable=False)
+    pig_name = db.Column(db.String(80), nullable=True)
+    earned_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+
+    __table_args__ = (
+        db.UniqueConstraint('user_id', 'code', name='ux_trophy_user_code'),
+    )
+
+    @classmethod
+    def award(cls, user_id: int, code: str, label: str, emoji: str, description: str, pig_name: str | None = None):
+        trophy = cls.query.filter_by(user_id=user_id, code=code).first()
+        if trophy:
+            return trophy
+        trophy = cls(user_id=user_id, code=code, label=label, emoji=emoji, description=description, pig_name=pig_name)
+        db.session.add(trophy)
+        return trophy
 
 
 class Race(db.Model):

--- a/race_engine.py
+++ b/race_engine.py
@@ -43,6 +43,7 @@ class RaceParticipant:
     intelligence: float = 10.0
     moral: float = 10.0
     strategy: int = 50
+    freshness: float = 100.0
     # État mutable pendant la simulation
     distance: float = 0.0
     fatigue: float = 0.0
@@ -73,6 +74,7 @@ class RaceParticipant:
             intelligence=float(_get('intelligence', 10)),
             moral=float(_get('moral', 10)),
             strategy=int(_get('strategy', 50)),
+            freshness=float(_get('freshness', 100.0)),
         )
 
 
@@ -179,7 +181,8 @@ class CourseManager:
             terrain_mod = RACE_BOUE_TERRAIN_MOD if segment['type'] == 'BOUE' else RACE_VIRAGE_TERRAIN_MOD
 
         # 5. Final Speed for this turn
-        final_speed = base_speed * strat_speed_mod * speed_penalty * terrain_mod
+        freshness_factor = 0.9 + (max(0.0, min(100.0, p.freshness)) / 1000.0)
+        final_speed = base_speed * strat_speed_mod * speed_penalty * terrain_mod * freshness_factor
 
         # 6. Apply stumble
         if stumble_roll:

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -5,7 +5,7 @@ import random
 import math
 
 from extensions import db
-from models import User, Pig, Bet, Auction
+from models import User, Pig, Bet, Auction, Trophy
 from data import PIG_ORIGINS, BET_TYPES, RARITIES
 from helpers import get_market_unlock_progress, get_market_lock_reason
 from services.finance_service import record_balance_transaction
@@ -129,6 +129,7 @@ def profil():
     bet_win_rate = round((len(won_bets) / len(settled_bets)) * 100, 1) if settled_bets else 0.0
 
     market_unlocked, market_progress_races, account_age_hours = get_market_unlock_progress(user)
+    memorial_trophies = Trophy.query.filter_by(user_id=user.id).order_by(Trophy.earned_at.desc(), Trophy.id.desc()).all()
     market_hours_left = max(0, int(math.ceil(24 - account_age_hours)))
 
     return render_template(
@@ -158,4 +159,5 @@ def profil():
         market_lock_reason=get_market_lock_reason(user),
         active_listing_count=get_active_listing_count(user),
         active_listing_ids=active_listing_ids,
+        memorial_trophies=memorial_trophies,
     )

--- a/routes/main.py
+++ b/routes/main.py
@@ -3,7 +3,7 @@ from sqlalchemy import func
 from datetime import datetime
 
 from extensions import db
-from models import User, Pig, Race, Participant, Bet, BalanceTransaction, CoursePlan
+from models import User, Pig, Race, Participant, Bet, BalanceTransaction, CoursePlan, Trophy
 from data import BET_TYPES, WEEKLY_BACON_TICKETS, DAILY_LOGIN_REWARD
 from helpers import ensure_next_race, get_user_active_pigs, get_race_history_entries
 from services.market_service import get_prix_moyen_groin, is_market_open, get_next_market_time
@@ -279,6 +279,9 @@ def classement():
         if legendary_dead >= 1: trophies.append({'n': 'Sacrilege', 'e': '⚱️', 'd': 'Avoir perdu un cochon legendaire'})
         if total_bets > 0 and len(won_bets) == 0: trophies.append({'n': 'La Poisse', 'e': '🐌', 'd': 'Aucun pari gagne'})
         if win_rate >= 40 and total_races >= 10: trophies.append({'n': 'Stratege', 'e': '🧠', 'd': '40%+ win rate (10+ courses)'})
+        memorial_trophies = Trophy.query.filter_by(user_id=u.id).order_by(Trophy.earned_at.asc()).all()
+        for trophy in memorial_trophies:
+            trophies.append({'n': trophy.label, 'e': trophy.emoji, 'd': trophy.description})
 
         rankings.append({
             'user': u,

--- a/routes/pig.py
+++ b/routes/pig.py
@@ -203,6 +203,7 @@ def share_snack():
     recipient_pig.hunger = min(100, recipient_pig.hunger + snack['hunger_restore'])
     recipient_pig.last_fed_at = datetime.utcnow()
     recipient_pig.last_updated = recipient_pig.last_fed_at
+    recipient_pig.reset_freshness()
     user.snack_shares_today = (user.snack_shares_today or 0) + 1
     user.snack_share_reset_at = datetime.utcnow()
     db.session.commit()
@@ -542,6 +543,8 @@ def typing_complete():
     pig.xp += 20
     pig.last_school_at = datetime.utcnow()
     pig.last_updated = pig.last_school_at
+    pig.reset_freshness()
+    pig.mark_bad_state_if_needed()
     pig.check_level_up()
     db.session.commit()
     

--- a/services/pig_service.py
+++ b/services/pig_service.py
@@ -42,16 +42,13 @@ class PigHeritageSnapshot:
 
 
 def get_freshness_bonus(pig):
-    if not pig or not pig.last_fed_at:
-        return {'active': False, 'multiplier': 1.0, 'bonus_percent': 0.0, 'hours_remaining': 0.0}
-    elapsed_hours = max(0.0, (datetime.utcnow() - pig.last_fed_at).total_seconds() / 3600.0)
-    active = elapsed_hours < FRESHNESS_BONUS_HOURS
-    remaining = max(0.0, FRESHNESS_BONUS_HOURS - elapsed_hours)
+    freshness_value = max(0.0, min(100.0, float(getattr(pig, 'freshness', 100.0) or 100.0))) if pig else 100.0
     return {
-        'active': active,
-        'multiplier': round(1.0 + FRESHNESS_MORAL_BONUS, 3) if active else 1.0,
-        'bonus_percent': round(FRESHNESS_MORAL_BONUS * 100, 1) if active else 0.0,
-        'hours_remaining': round(remaining, 2),
+        'active': freshness_value >= 95.0,
+        'multiplier': 1.0,
+        'bonus_percent': 0.0,
+        'hours_remaining': 0.0,
+        'value': round(freshness_value, 1),
     }
 
 

--- a/services/race_service.py
+++ b/services/race_service.py
@@ -281,11 +281,11 @@ def get_pig_dashboard_status(pig):
     health_base = ((pig.energy or 0) * 0.4) + ((pig.hunger or 0) * 0.25) + ((pig.happiness or 0) * 0.35) - (35 if pig.is_injured else 0)
     health_pct = max(0, min(100, int(round(health_base))))
     if rest_days >= 5:
-        rest_label, rest_note = 'Frais comme un Porcelet', "Long repos accumule. Excellent signal pour un retour qui claque."
+        rest_label, rest_note = 'En pause cafe', "Il prend son temps loin de la piste. La fraicheur remontera au premier geste positif."
     elif rest_days >= 2:
-        rest_label, rest_note = 'Repos utile', "Le cochon recharge tranquillement ses batteries avant sa prochaine sortie."
+        rest_label, rest_note = 'Se repose', "Un rythme doux, parfait pour garder le cochon serein avant la prochaine sortie."
     else:
-        rest_label, rest_note = 'Rythme soutenu', "Mieux vaut surveiller les enchainements de courses et la fatigue."
+        rest_label, rest_note = 'Routine legere', "Petit passage recent sur la piste, rien d'alarmant : il suit simplement son tempo."
     return {'health_pct': health_pct, 'fatigue_pct': fatigue_pct, 'rest_days': rest_days, 'last_race_at': last_race_at, 'rest_label': rest_label, 'rest_note': rest_note}
 
 

--- a/templates/mon_cochon.html
+++ b/templates/mon_cochon.html
@@ -334,12 +334,12 @@
                         {% endif %}
                         <div class="px-3 py-3 rounded-xl border {{ 'border-emerald-400/20 bg-emerald-500/10' if freshness.active else 'border-white/10 bg-white/5' }}">
                             <div class="flex items-center justify-between text-[10px] font-bold uppercase">
-                                <span class="{{ 'text-emerald-200' if freshness.active else 'text-white/45' }}">Fraicheur de repas</span>
-                                <span class="{{ 'text-emerald-300' if freshness.active else 'text-white/35' }}">{% if freshness.active %}+{{ "%.0f"|format(freshness.bonus_percent) }}% moral{% else %}Aucun bonus{% endif %}</span>
+                                <span class="text-emerald-200">Fraicheur</span>
+                                <span class="text-emerald-300">{{ "%.0f"|format(pig.freshness or 100) }}%</span>
                             </div>
-                            {% set fresh_val = 100 if freshness.active else 0 %}
-                            <div class="mt-2 stat-bar border border-white/5"><div class="stat-bar-fill {{ 'bg-emerald-400' if freshness.active else 'bg-white/20' }}" style="width: {{ fresh_val }}%"></div></div>
-                            <p class="mt-2 text-[11px] font-bold {{ 'text-emerald-100' if freshness.active else 'text-white/35' }}">{% if freshness.active %}Le prochain depart profite encore du dernier repas. Fenetre restante: ~{{ "%.1f"|format(freshness.hours_remaining) }} h.{% else %}Un repas dans les 2 prochaines heures relance le buff de fraicheur avant la course.{% endif %}</p>
+                            {% set fresh_val = pig.freshness or 100 %}
+                            <div class="mt-2 stat-bar border border-white/5"><div class="stat-bar-fill bg-emerald-400" style="width: {{ fresh_val }}%"></div></div>
+                            <p class="mt-2 text-[11px] font-bold text-emerald-100">Toute action positive remet la jauge a 100. Sans activite, la fraicheur ne commence a baisser qu'apres 48 h et reste en treve du vendredi soir au lundi matin.</p>
                         </div>
                     </div>
                 </div>

--- a/templates/profil.html
+++ b/templates/profil.html
@@ -201,6 +201,31 @@
             </div>
 
             <div class="card p-6">
+                <div class="flex items-center justify-between gap-3 mb-4">
+                    <h2 class="font-title text-2xl text-white">Palmares memoire</h2>
+                    <span class="px-3 py-1 rounded-full text-xs font-bold status-ok">{{ memorial_trophies|length }} trophée{{ 's' if memorial_trophies|length != 1 else '' }}</span>
+                </div>
+                {% if memorial_trophies %}
+                <div class="space-y-3">
+                    {% for trophy in memorial_trophies %}
+                    <div class="pig-pill p-4">
+                        <div class="flex items-start gap-3">
+                            <div class="text-2xl">{{ trophy.emoji }}</div>
+                            <div>
+                                <p class="text-white font-bold">{{ trophy.label }}</p>
+                                <p class="text-white/55 text-sm font-semibold">{{ trophy.description }}</p>
+                                <p class="text-white/35 text-xs font-bold mt-1">{{ trophy.pig_name or 'Elevage' }} • {{ trophy.earned_at.strftime('%d/%m/%Y') if trophy.earned_at else 'archive' }}</p>
+                            </div>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% else %}
+                <p class="text-white/45 text-sm font-semibold">Aucun trophée mémoriel pour l'instant. Les grands exploits survivront ici après la fin de carrière d'un cochon.</p>
+                {% endif %}
+            </div>
+
+            <div class="card p-6">
                 <h2 class="font-title text-2xl text-white mb-2">Mot de passe</h2>
                 <p class="text-white/45 text-sm font-semibold mb-5">Change ton mot de passe sans quitter la piste.</p>
                 <form method="POST" action="/profil" class="space-y-4">


### PR DESCRIPTION
### Motivation
- Remplacer la mécanique de perte de niveau par une jauge persistante de « fraîcheur » plus douce et maîtrisée, et conserver certains exploits (trophées) au niveau utilisateur après la fin de vie d’un cochon.
- Rendre l’affichage du tableau de bord plus « low-stress » (messages de repos) et montrer un palmarès mémoriel au profil.

### Description
- Ajout du champ `freshness` (float 0–100, défaut 100) et du flag `ever_bad_state` sur le modèle `Pig`, et création d’un modèle `Trophy` pour stocker les trophées persistants utilisateur (migration SQLite incluse).
- Implémentation de la décroissance de fraîcheur dans `Pig.update_vitals()` : la jauge ne commence à baisser qu’après 48h d’inactivité, à raison de 5 points par jour (converti en points/heure), et la trêve week-end est respectée via `calculate_weekend_truce_hours()`.
- Réinitialisation immédiate de `freshness` à 100 sur actions positives (`feed`, `train`, `study`, partage d’en-cas, typing), et mémorisation du passage en « mauvais état » via `ever_bad_state` (méthode `mark_bad_state_if_needed`).
- Impact en course : transport de la fraîcheur dans `RaceParticipant` et application d’un coefficient sur la `final_speed` (ex. freshness=50 → ~5% malus via le coefficient implémenté dans `race_engine.py`).
- Trophées mémoriels : nouveau `Trophy.award()` et attribution automatique pour : « Le Pilier de Bureau » (cochon vivant > 3 mois réels), « Retour Gagnant » (victoire en partant avec fraîcheur < 80%), et « Retraite Dorée » (atteinte de `max_races` sans jamais être passé en mauvais état); `kill()` / `retire()` déclenchent l’enregistrement si conditions remplies.
- UI/UX : texte du dashboard adouci (`get_pig_dashboard_status`) — affichages « En pause café / Se repose / Routine légère » — et affichage d’une jauge de fraîcheur sur la fiche cochon ainsi qu’un bloc « Palmarès mémoire » sur la page profil; les trophées mémoriels sont aussi injectés dans le classement global.

### Testing
- Compilation statique des modules modifiés : `python -m py_compile models.py race_engine.py app.py helpers.py services/pig_service.py services/race_service.py routes/pig.py routes/auth.py routes/main.py` (succès).
- Démarrage rapide d’app et vérification DB en contexte : création/lecture de `Trophy` et existence du champ `freshness` sur un cochon ; sortie attendue imprimée (`trophy_table True`, `sample_pig_has_freshness True 100.0`) (succès).
- Vérification `git diff --check` et commit effectué (`Add pig freshness and memorial trophies`).
- Note : aucune capture d’écran navigateur n’a été réalisée (outil non disponible dans cet environnement).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1f7c759883238118ffc7c97798ee)