### PR TITLE
Add pig freshness progression and comeback trophies

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,6 +71,8 @@ def migrate_db():
         ('pig', 'origin_flag', 'VARCHAR(10) DEFAULT "🇫🇷"'),
         ('pig', 'last_school_at', 'DATETIME'),
         ('pig', 'last_fed_at', 'DATETIME'),
+        ('pig', 'last_interaction_at', 'DATETIME'),
+        ('pig', 'comeback_bonus_ready', 'BOOLEAN DEFAULT 0'),
         ('pig', 'school_sessions_completed', 'INTEGER DEFAULT 0'),
         ('pig', 'weight_kg', 'FLOAT DEFAULT 112.0'),
         ('pig', 'freshness', 'FLOAT DEFAULT 100.0'),

--- a/helpers.py
+++ b/helpers.py
@@ -1356,6 +1356,7 @@ def run_race_if_needed():
 
         participants_by_id = {participant.id: participant for participant in participants}
         pig_start_freshness = {}
+        pig_comeback_bonus_flags = {}
 
         # New Tactical Simulation
         # Fetch actual pig stats for simulation
@@ -1366,20 +1367,27 @@ def run_race_if_needed():
                 if pig:
                     pig.strategy = p.strategy # Sync current player strategy
                     pig_start_freshness[p.pig_id] = float(pig.freshness or 100.0)
-                    pigs_for_sim.append(pig)
+                    pig_comeback_bonus_flags[p.pig_id] = bool(pig.comeback_bonus_ready)
+                    pigs_for_sim.append({
+                        'id': pig.id, 'name': pig.name, 'emoji': pig.emoji,
+                        'vitesse': pig.vitesse, 'endurance': pig.endurance, 'force': pig.force, 'agilite': pig.agilite,
+                        'intelligence': pig.intelligence, 'moral': pig.moral, 'strategy': p.strategy,
+                        'freshness': pig.freshness, 'is_happy': (pig.freshness or 0) > 90.0,
+                        'speed_bonus_multiplier': 1.1 if pig.comeback_bonus_ready else 1.0,
+                    })
                 else:
                     # Mock NPC pig stats based on odds
                     pigs_for_sim.append({
                         'id': p.id, 'name': p.name, 'emoji': p.emoji,
                         'vitesse': 20 + (1.0/p.odds)*100, 'endurance': 30, 'force': 30, 'agilite': 30,
-                        'intelligence': 30, 'moral': 50, 'strategy': 50
+                        'intelligence': 30, 'moral': 50, 'strategy': 50, 'freshness': 100.0, 'is_happy': True,
                     })
             else:
                 # Mock NPC pig stats based on odds
                 pigs_for_sim.append({
                     'id': p.id, 'name': p.name, 'emoji': p.emoji,
                     'vitesse': 20 + (1.0/p.odds)*100, 'endurance': 30, 'force': 30, 'agilite': 30,
-                    'intelligence': 30, 'moral': 50, 'strategy': 50
+                    'intelligence': 30, 'moral': 50, 'strategy': 50, 'freshness': 100.0, 'is_happy': True,
                 })
 
         segments = generate_course_segments()
@@ -1466,6 +1474,16 @@ def run_race_if_needed():
                             description="Gagner une course en partant avec moins de 80% de fraicheur.",
                             pig_name=pig.name,
                         )
+                    if pig_comeback_bonus_flags.get(pig.id) and owner:
+                        from models import Trophy
+                        Trophy.award(
+                            user_id=owner.id,
+                            code='coup_de_collier',
+                            label='Coup de Collier',
+                            emoji='💼',
+                            description="Remporter une course juste apres une periode d'inactivite.",
+                            pig_name=pig.name,
+                        )
                     pig.vitesse = min(100, pig.vitesse + random.uniform(0.5, 1.5))
                     pig.endurance = min(100, pig.endurance + random.uniform(0.5, 1.5))
                     pig.moral = min(100, pig.moral + 2)
@@ -1475,6 +1493,7 @@ def run_race_if_needed():
                     setattr(pig, stat, min(100, getattr(pig, stat) + random.uniform(0.3, 0.8)))
 
                 pig.energy = max(0, pig.energy - 15)
+                pig.comeback_bonus_ready = False
                 pig.hunger = max(0, pig.hunger - 10)
                 pig.adjust_weight(-0.3)
                 pig.mark_bad_state_if_needed()

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import json
 import random
 
@@ -142,6 +142,8 @@ class Pig(db.Model):
     last_updated = db.Column(db.DateTime, default=datetime.utcnow)
     last_school_at = db.Column(db.DateTime, nullable=True)
     last_fed_at = db.Column(db.DateTime, nullable=True)
+    last_interaction_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=True)
+    comeback_bonus_ready = db.Column(db.Boolean, default=False)
 
     lineage_name = db.Column(db.String(80), nullable=True)
     generation = db.Column(db.Integer, default=1)
@@ -214,6 +216,31 @@ class Pig(db.Model):
         """Remet la fraicheur a fond apres une interaction positive."""
         self.freshness = 100.0
 
+    def register_positive_interaction(self, interacted_at: datetime | None = None):
+        """Enregistre une interaction joueur et prepare le bonus de retrouvailles."""
+        interaction_time = interacted_at or datetime.utcnow()
+        previous_interaction = self.last_interaction_at or self.last_updated or self.created_at
+        if previous_interaction and (interaction_time - previous_interaction).total_seconds() > 3 * 24 * 3600:
+            self.comeback_bonus_ready = True
+        self.last_interaction_at = interaction_time
+        self.last_updated = interaction_time
+        self.reset_freshness()
+
+    def award_longevity_trophies(self):
+        """Attribue un trophee par mois reel de vie."""
+        if not self.owner or not self.created_at:
+            return
+        months_alive = max(0, (datetime.utcnow() - self.created_at).days // 30)
+        for month_index in range(1, months_alive + 1):
+            Trophy.award(
+                user_id=self.owner.id,
+                code=f'ancient_one_month_{month_index}',
+                label="L'Ancien",
+                emoji='🕰️',
+                description=f"{self.name} a traverse {month_index} mois reel(s) de bureau sans quitter la porcherie.",
+                pig_name=self.name,
+            )
+
     def mark_bad_state_if_needed(self):
         """Memorise si le cochon est deja passe par un mauvais etat."""
         if (self.hunger or 0) < 20 or (self.energy or 0) < 20:
@@ -250,8 +277,7 @@ class Pig(db.Model):
         self.adjust_weight(cereal.get('weight_delta', 0.0))
         self.apply_stat_boosts(cereal.get('stats', {}))
         self.last_fed_at = datetime.utcnow()
-        self.last_updated = self.last_fed_at
-        self.reset_freshness()
+        self.register_positive_interaction(self.last_fed_at)
         self.mark_bad_state_if_needed()
 
     def train(self, training: dict):
@@ -263,8 +289,7 @@ class Pig(db.Model):
         if 'happiness_bonus' in training:
             self.happiness = min(100, self.happiness + training['happiness_bonus'])
         self.apply_stat_boosts(training.get('stats', {}))
-        self.reset_freshness()
-        self.last_updated = datetime.utcnow()
+        self.register_positive_interaction(datetime.utcnow())
         self.mark_bad_state_if_needed()
 
     def study(self, lesson: dict, correct: bool) -> str:
@@ -285,8 +310,7 @@ class Pig(db.Model):
             self.happiness = max(0, self.happiness - lesson.get('wrong_happiness_penalty', 0))
             category = 'warning'
 
-        self.reset_freshness()
-        self.last_updated = datetime.utcnow()
+        self.register_positive_interaction(datetime.utcnow())
         self.mark_bad_state_if_needed()
         self.check_level_up()
         return category
@@ -342,6 +366,7 @@ class Pig(db.Model):
         from data import DEFAULT_PIG_WEIGHT_KG
 
         now = datetime.utcnow()
+        self.award_longevity_trophies()
         if not self.last_updated:
             self.last_updated = now
             return
@@ -356,9 +381,19 @@ class Pig(db.Model):
             db.session.commit()
             return
 
-        freshness_decay_hours = max(0.0, effective_hours - 48.0)
-        if freshness_decay_hours > 0:
-            self.freshness = max(0.0, (self.freshness or 100.0) - (freshness_decay_hours * (5.0 / 24.0)))
+        reference_interaction = self.last_interaction_at or self.last_updated
+        if reference_interaction:
+            grace_deadline = reference_interaction + timedelta(hours=48)
+            if now > grace_deadline:
+                elapsed_workdays = 0
+                cursor = grace_deadline.date()
+                while cursor <= now.date():
+                    if cursor.weekday() < 5:
+                        elapsed_workdays += 1
+                    cursor += timedelta(days=1)
+                self.freshness = max(0.0, 100.0 - (elapsed_workdays * 5.0))
+            else:
+                self.freshness = 100.0
 
         # Faim décroît avec le temps
         self.hunger = max(0, self.hunger - hours * 2)

--- a/race_engine.py
+++ b/race_engine.py
@@ -44,6 +44,8 @@ class RaceParticipant:
     moral: float = 10.0
     strategy: int = 50
     freshness: float = 100.0
+    is_happy: bool = False
+    speed_bonus_multiplier: float = 1.0
     # État mutable pendant la simulation
     distance: float = 0.0
     fatigue: float = 0.0
@@ -75,6 +77,8 @@ class RaceParticipant:
             moral=float(_get('moral', 10)),
             strategy=int(_get('strategy', 50)),
             freshness=float(_get('freshness', 100.0)),
+            is_happy=bool(_get('is_happy', float(_get('freshness', 100.0)) > 90.0)),
+            speed_bonus_multiplier=float(_get('speed_bonus_multiplier', 1.0)),
         )
 
 
@@ -182,7 +186,7 @@ class CourseManager:
 
         # 5. Final Speed for this turn
         freshness_factor = 0.9 + (max(0.0, min(100.0, p.freshness)) / 1000.0)
-        final_speed = base_speed * strat_speed_mod * speed_penalty * terrain_mod * freshness_factor
+        final_speed = base_speed * strat_speed_mod * speed_penalty * terrain_mod * freshness_factor * p.speed_bonus_multiplier
 
         # 6. Apply stumble
         if stumble_roll:
@@ -218,6 +222,7 @@ class CourseManager:
                     'is_finished': p.is_finished,
                     'stumbled': p.stumbled,
                     'has_draft': p.has_draft,
+                    'is_happy': p.is_happy,
                 }
                 for p in self.participants
             ],

--- a/routes/pig.py
+++ b/routes/pig.py
@@ -202,8 +202,7 @@ def share_snack():
     recipient_pig.update_vitals()
     recipient_pig.hunger = min(100, recipient_pig.hunger + snack['hunger_restore'])
     recipient_pig.last_fed_at = datetime.utcnow()
-    recipient_pig.last_updated = recipient_pig.last_fed_at
-    recipient_pig.reset_freshness()
+    recipient_pig.register_positive_interaction(recipient_pig.last_fed_at)
     user.snack_shares_today = (user.snack_shares_today or 0) + 1
     user.snack_share_reset_at = datetime.utcnow()
     db.session.commit()

--- a/services/pig_service.py
+++ b/services/pig_service.py
@@ -154,40 +154,7 @@ def get_pig_performance_flags(pig):
 
 
 def update_pig_state(pig):
-    now = datetime.utcnow()
-    if not pig.last_updated:
-        pig.last_updated = now
-        return
-    elapsed_hours = (now - pig.last_updated).total_seconds() / 3600
-    if elapsed_hours < 0.01:
-        return
-    truce_hours = calculate_weekend_truce_hours(pig.last_updated, now)
-    hours = max(0.0, elapsed_hours - truce_hours)
-    hours = min(hours, 24)
-    if hours < 0.01:
-        pig.last_updated = now
-        db.session.commit()
-        return
-    pig.hunger = max(0, pig.hunger - hours * 2)
-    if pig.hunger > 30:
-        pig.energy = min(100, pig.energy + hours * 5)
-    else:
-        pig.energy = max(0, pig.energy - hours * 1)
-    if pig.hunger < 15:
-        pig.happiness = max(0, pig.happiness - hours * 3)
-    elif pig.hunger < 30:
-        pig.happiness = max(0, pig.happiness - hours * 1)
-    elif pig.happiness < 60:
-        pig.happiness = min(60, pig.happiness + hours * 0.3)
-    current_weight = pig.weight_kg or DEFAULT_PIG_WEIGHT_KG
-    if pig.hunger < 25:
-        pig.weight_kg = clamp_pig_weight(current_weight - hours * 0.25)
-    elif pig.hunger > 75 and pig.energy < 45:
-        pig.weight_kg = clamp_pig_weight(current_weight + hours * 0.18)
-    elif pig.energy > 80 and pig.hunger < 60:
-        pig.weight_kg = clamp_pig_weight(current_weight - hours * 0.08)
-    pig.last_updated = now
-    db.session.commit()
+    pig.update_vitals()
 
 
 def calculate_pig_power(pig):


### PR DESCRIPTION
### Motivation
- Valoriser la longévité et la collection sans ajout de gestion stressante en traçant les interactions et en récompensant la fidélité et les retours après inactivité.
- Permettre des retours palpables en course (`Effet Sortie de Bureau`) et fournir des marqueurs visibles dans l'historique pour déclencher des animations côté client.

### Description
- Ajout de deux champs persistés sur `Pig`: `last_interaction_at` et `comeback_bonus_ready`, et adaptation de la migration pour les créer; centralisation des interactions positives via `Pig.register_positive_interaction`.
- Implémentation de la décroissance de fraîcheur : après 48h de silence la fraîcheur diminue de `-5%` par jour ouvré dans `Pig.update_vitals`, et attribution périodique des trophées `L'Ancien` via `Pig.award_longevity_trophies` (un trophée par mois réel de vie).
- Mise en place du bonus de retrouvailles : si l'utilisateur revient après >3 jours, `comeback_bonus_ready` est défini, le multiplicateur de vitesse `speed_bonus_multiplier` (x1.1 soit +10% vitesse) est appliqué dans la simulation via `CourseManager`/`RaceParticipant`, et la victoire dans cette fenêtre attribue le trophée `Coup de Collier` et consomme le bonus.
- Ajustements d'intégration : `race.replay_json` inclut maintenant le flag `is_happy` (fraîcheur > 90%) pour l'animation front, `routes/pig.share_snack` utilise `register_positive_interaction`, et `services.pig_service.update_pig_state` délègue à `Pig.update_vitals` pour éviter la duplication de logique.

### Testing
- Code checked for syntax with `python -m py_compile app.py models.py helpers.py race_engine.py routes/pig.py services/pig_service.py services/race_service.py` and compilation succeeded.
- Integration smoke test run with `DERBY_DISABLE_SCHEDULER=1 python - <<'PY' ... PY` validated freshness decay, `comeback_bonus_ready` toggle via `register_positive_interaction`, awarding of `L'Ancien` trophies, and that `CourseManager` history contains `is_happy`; the script printed `integration-check-ok` indicating success.
- All local checks and the lightweight simulation assertions ran and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf210ed1508323a6a3e5b22701286a)