### PR TITLE
Flamme Rouge: segmented strategy profiles, live telemetry & memorial trophies

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,6 +94,7 @@ def migrate_db():
         ('participant', 'strategy', 'INTEGER DEFAULT 50'),
         ('race', 'replay_json', 'TEXT'),
         ('course_plan', 'strategy', 'INTEGER DEFAULT 50'),
+        ('course_plan', 'strategy_profile', 'TEXT DEFAULT \'{"phase_1": 35, "phase_2": 50, "phase_3": 80}\''),
         ('auction', 'seller_id', 'INTEGER'),
         ('auction', 'source_pig_id', 'INTEGER'),
         ('auction', 'pig_weight', 'FLOAT DEFAULT 112.0'),
@@ -103,6 +104,8 @@ def migrate_db():
         ('bet', 'selection_order', 'VARCHAR(240)'),
         ('user', 'last_daily_reward_at', 'DATETIME'),
         ('trophy', 'pig_name', 'VARCHAR(80)'),
+        ('trophy', 'trophy_key', 'VARCHAR(50)'),
+        ('trophy', 'date_earned', 'DATETIME'),
     ]
     table_migrations = [
         """CREATE TABLE IF NOT EXISTS trophy (
@@ -145,6 +148,24 @@ def migrate_db():
                 conn.commit()
             except Exception:
                 pass
+        try:
+            conn.execute(db.text("""
+                UPDATE course_plan
+                SET strategy_profile = json_object(
+                    'phase_1', COALESCE(strategy, 50),
+                    'phase_2', COALESCE(strategy, 50),
+                    'phase_3', COALESCE(strategy, 50)
+                )
+                WHERE strategy_profile IS NULL OR strategy_profile = ''
+            """))
+            conn.execute(db.text("""
+                UPDATE trophy
+                SET trophy_key = COALESCE(trophy_key, code),
+                    date_earned = COALESCE(date_earned, earned_at)
+            """))
+            conn.commit()
+        except Exception:
+            pass
 
 
 def seed_users():

--- a/helpers.py
+++ b/helpers.py
@@ -899,7 +899,8 @@ def populate_race_participants(race, respect_course_plans=True, allow_rebuild_if
         all_powers.append(power)
         owner = User.query.get(pig.user_id)
         plan = CoursePlan.query.filter_by(pig_id=pig.id, scheduled_at=race.scheduled_at).first()
-        strategy = plan.strategy if plan else 50
+        plan_profile = plan.strategy_segments if plan else {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
+        strategy = plan_profile['phase_1']
         participant = Participant(
             race_id=race.id,
             name=pig.name,
@@ -1000,14 +1001,11 @@ def build_course_schedule(user, pigs, days=30):
             is_actual_participant = pig.id in slot_actual_pig_ids
             is_planned = pig.id in slot_user_plan_by_pig
             
-            # Find current strategy if already participant
-            current_strategy = 50
-            if is_actual_participant:
-                part = next((p for p in slot_participants if p.pig_id == pig.id), None)
-                if part:
-                    current_strategy = part.strategy
-            elif is_planned:
-                current_strategy = slot_user_plan_by_pig[pig.id].strategy
+            current_strategy = (
+                slot_user_plan_by_pig[pig.id].strategy_segments
+                if is_planned else
+                {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
+            )
 
             exclude_slot = slot_time if (is_actual_participant or is_planned) else None
             weekly_commitments = count_pig_weekly_course_commitments(pig.id, slot_time, exclude_scheduled_at=exclude_slot)
@@ -1032,7 +1030,8 @@ def build_course_schedule(user, pigs, days=30):
                 'pig': pig,
                 'is_planned': is_planned,
                 'is_actual_participant': is_actual_participant,
-                'current_strategy': current_strategy,
+                'current_strategy_profile': current_strategy,
+                'current_strategy_summary': f"D {current_strategy['phase_1']} • M {current_strategy['phase_2']} • F {current_strategy['phase_3']}",
                 'can_toggle': can_toggle,
                 'disabled_reason': disabled_reason,
                 'weekly_commitments': projected_commitments,
@@ -1365,13 +1364,15 @@ def run_race_if_needed():
             if p.pig_id:
                 pig = Pig.query.get(p.pig_id)
                 if pig:
-                    pig.strategy = p.strategy # Sync current player strategy
                     pig_start_freshness[p.pig_id] = float(pig.freshness or 100.0)
                     pig_comeback_bonus_flags[p.pig_id] = bool(pig.comeback_bonus_ready)
+                    plan = CoursePlan.query.filter_by(pig_id=pig.id, scheduled_at=race.scheduled_at).first()
+                    strategy_profile = plan.strategy_segments if plan else {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
                     pigs_for_sim.append({
                         'id': pig.id, 'name': pig.name, 'emoji': pig.emoji,
                         'vitesse': pig.vitesse, 'endurance': pig.endurance, 'force': pig.force, 'agilite': pig.agilite,
                         'intelligence': pig.intelligence, 'moral': pig.moral, 'strategy': p.strategy,
+                        'strategy_profile': strategy_profile,
                         'freshness': pig.freshness, 'is_happy': (pig.freshness or 0) > 90.0,
                         'speed_bonus_multiplier': 1.1 if pig.comeback_bonus_ready else 1.0,
                     })

--- a/models.py
+++ b/models.py
@@ -250,6 +250,15 @@ class Pig(db.Model):
         """Attribue les trophees memoriels lies a la fin de carriere."""
         if not self.owner:
             return
+        if self.created_at and (datetime.utcnow() - self.created_at).days >= 30:
+            Trophy.award(
+                user_id=self.owner.id,
+                code='office_elder',
+                label="L'Ancien du Bureau",
+                emoji='🗄️',
+                description='Un cochon a tenu plus de 30 jours reels avant son post-mortem.',
+                pig_name=self.name,
+            )
         if self.created_at and (datetime.utcnow() - self.created_at).days >= 90:
             Trophy.award(
                 user_id=self.owner.id,
@@ -268,6 +277,50 @@ class Pig(db.Model):
                 description="Atteindre la limite de courses sans jamais tomber en mauvais etat.",
                 pig_name=self.name,
             )
+        winning_track_profiles = self.get_winning_track_profiles()
+        if len(winning_track_profiles) >= 3:
+            Trophy.award(
+                user_id=self.owner.id,
+                code='segment_expert',
+                label='Expert des Segments',
+                emoji='🧭',
+                description='Ce cochon a gagne sur 3 profils de piste differents.',
+                pig_name=self.name,
+            )
+        if (self.school_sessions_completed or 0) > 20:
+            Trophy.award(
+                user_id=self.owner.id,
+                code='iron_memory',
+                label='Memoire de Fer',
+                emoji='🧠',
+                description="Plus de 20 passages a l'ecole porcine avant la fin de carriere.",
+                pig_name=self.name,
+            )
+
+    def get_winning_track_profiles(self) -> set[str]:
+        if not self.id:
+            return set()
+        winning_rows = (
+            db.session.query(Race.replay_json)
+            .join(Participant, Participant.race_id == Race.id)
+            .filter(
+                Participant.pig_id == self.id,
+                Participant.finish_position == 1,
+                Race.status == 'finished',
+            )
+            .all()
+        )
+        profiles = set()
+        for (replay_json,) in winning_rows:
+            if not replay_json:
+                continue
+            try:
+                replay = json.loads(replay_json)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(replay, dict) and replay.get('track_profile'):
+                profiles.add(replay['track_profile'])
+        return profiles
 
     def feed(self, cereal: dict):
         """Nourrir le cochon avec une céréale (dict issu de data.CEREALS).
@@ -430,11 +483,13 @@ class Pig(db.Model):
 class Trophy(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False, index=True)
+    trophy_key = db.Column(db.String(50), nullable=True)
     code = db.Column(db.String(50), nullable=False)
     label = db.Column(db.String(80), nullable=False)
     emoji = db.Column(db.String(10), nullable=False, default='🏆')
     description = db.Column(db.String(255), nullable=False)
     pig_name = db.Column(db.String(80), nullable=True)
+    date_earned = db.Column(db.DateTime, nullable=True, index=True)
     earned_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
 
     __table_args__ = (
@@ -446,7 +501,16 @@ class Trophy(db.Model):
         trophy = cls.query.filter_by(user_id=user_id, code=code).first()
         if trophy:
             return trophy
-        trophy = cls(user_id=user_id, code=code, label=label, emoji=emoji, description=description, pig_name=pig_name)
+        trophy = cls(
+            user_id=user_id,
+            trophy_key=code,
+            code=code,
+            label=label,
+            emoji=emoji,
+            description=description,
+            pig_name=pig_name,
+            date_earned=datetime.utcnow(),
+        )
         db.session.add(trophy)
         return trophy
 
@@ -505,8 +569,40 @@ class CoursePlan(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False, index=True)
     pig_id = db.Column(db.Integer, db.ForeignKey('pig.id'), nullable=False, index=True)
     scheduled_at = db.Column(db.DateTime, nullable=False, index=True)
-    strategy = db.Column(db.Integer, default=50)
+    strategy_profile = db.Column(
+        db.Text,
+        nullable=False,
+        default='{"phase_1": 35, "phase_2": 50, "phase_3": 80}',
+    )
     created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+
+    @staticmethod
+    def build_strategy_profile(phase_1=35, phase_2=50, phase_3=80) -> str:
+        return json.dumps({
+            'phase_1': int(phase_1),
+            'phase_2': int(phase_2),
+            'phase_3': int(phase_3),
+        })
+
+    @property
+    def strategy_segments(self) -> dict:
+        default_profile = {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
+        if not self.strategy_profile:
+            return default_profile
+        try:
+            profile = json.loads(self.strategy_profile)
+        except (TypeError, ValueError):
+            return default_profile
+        return {
+            'phase_1': int(profile.get('phase_1', default_profile['phase_1'])),
+            'phase_2': int(profile.get('phase_2', default_profile['phase_2'])),
+            'phase_3': int(profile.get('phase_3', default_profile['phase_3'])),
+        }
+
+    @property
+    def strategy_summary(self) -> str:
+        profile = self.strategy_segments
+        return f"Départ {profile['phase_1']} • Milieu {profile['phase_2']} • Final {profile['phase_3']}"
 
     pig = db.relationship('Pig', backref=db.backref('course_plans', lazy=True))
 

--- a/race_engine.py
+++ b/race_engine.py
@@ -43,6 +43,7 @@ class RaceParticipant:
     intelligence: float = 10.0
     moral: float = 10.0
     strategy: int = 50
+    strategy_profile: dict = field(default_factory=lambda: {'phase_1': 35, 'phase_2': 50, 'phase_3': 80})
     freshness: float = 100.0
     is_happy: bool = False
     speed_bonus_multiplier: float = 1.0
@@ -65,6 +66,13 @@ class RaceParticipant:
                 return source.get(key, default)
             return default
 
+        strategy_profile = _get('strategy_profile', {'phase_1': 35, 'phase_2': 50, 'phase_3': 80})
+        if isinstance(strategy_profile, str):
+            try:
+                strategy_profile = json.loads(strategy_profile)
+            except (TypeError, ValueError):
+                strategy_profile = {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
+
         return cls(
             id=_get('id', 0),
             name=_get('name', 'Inconnu'),
@@ -76,6 +84,7 @@ class RaceParticipant:
             intelligence=float(_get('intelligence', 10)),
             moral=float(_get('moral', 10)),
             strategy=int(_get('strategy', 50)),
+            strategy_profile=strategy_profile,
             freshness=float(_get('freshness', 100.0)),
             is_happy=bool(_get('is_happy', float(_get('freshness', 100.0)) > 90.0)),
             speed_bonus_multiplier=float(_get('speed_bonus_multiplier', 1.0)),
@@ -104,6 +113,28 @@ class CourseManager:
         self.total_length = sum(s['length'] for s in segments)
         self.history: list[dict] = []
         self.current_turn: int = 0
+        self.track_profile = self._compute_track_profile()
+
+    def _compute_track_profile(self) -> str:
+        terrain_lengths = {}
+        for seg in self.segments:
+            seg_type = seg.get('type', 'PLAT')
+            terrain_lengths[seg_type] = terrain_lengths.get(seg_type, 0) + seg.get('length', 0)
+        filtered = {k: v for k, v in terrain_lengths.items() if k != 'PLAT'}
+        profile_source = filtered or terrain_lengths or {'PLAT': 0}
+        return max(profile_source, key=profile_source.get)
+
+    def _resolve_phase_strategy(self, participant: RaceParticipant, segment_index: int) -> int:
+        total_segments = max(1, len(self.segments))
+        phase_step = total_segments / 3
+        if segment_index < phase_step:
+            phase_key = 'phase_1'
+        elif segment_index < phase_step * 2:
+            phase_key = 'phase_2'
+        else:
+            phase_key = 'phase_3'
+        profile = participant.strategy_profile or {}
+        return int(profile.get(phase_key, participant.strategy))
 
     def run(self):
         """Lance la simulation complète."""
@@ -122,11 +153,15 @@ class CourseManager:
             # Find current segment
             temp_dist = 0
             current_seg = self.segments[-1]
-            for seg in self.segments:
+            current_seg_index = len(self.segments) - 1
+            for seg_index, seg in enumerate(self.segments):
                 temp_dist += seg['length']
                 if p.distance < temp_dist:
                     current_seg = seg
+                    current_seg_index = seg_index
                     break
+
+            p.strategy = self._resolve_phase_strategy(p, current_seg_index)
 
             progression = self.calculate_progression(p, current_seg)
             p.distance += progression
@@ -222,7 +257,15 @@ class CourseManager:
                     'is_finished': p.is_finished,
                     'stumbled': p.stumbled,
                     'has_draft': p.has_draft,
+                    'is_drafting': p.has_draft,
                     'is_happy': p.is_happy,
+                    'strategy': p.strategy,
+                    'visual_event': (
+                        'stumble' if p.stumbled
+                        else 'sprint' if p.strategy > 80
+                        else 'tired' if p.fatigue > p.endurance
+                        else None
+                    ),
                 }
                 for p in self.participants
             ],
@@ -230,4 +273,8 @@ class CourseManager:
         self.history.append(turn_data)
 
     def to_json(self):
-        return json.dumps(self.history)
+        return json.dumps({
+            'track_profile': self.track_profile,
+            'segments': self.segments,
+            'turns': self.history,
+        })

--- a/routes/race.py
+++ b/routes/race.py
@@ -67,10 +67,14 @@ def plan_course():
 
     pig_id = request.form.get('pig_id', type=int)
     scheduled_at_raw = (request.form.get('scheduled_at') or '').strip()
-    strategy = request.form.get('strategy', 50, type=int)
+    strategy_profile = {
+        'phase_1': request.form.get('strategy_phase_1', 35, type=int),
+        'phase_2': request.form.get('strategy_phase_2', 50, type=int),
+        'phase_3': request.form.get('strategy_phase_3', 80, type=int),
+    }
 
     try:
-        action = plan_pig_for_race(user.id, pig_id, scheduled_at_raw, strategy)
+        action = plan_pig_for_race(user.id, pig_id, scheduled_at_raw, strategy_profile)
     except RacePlanningError as exc:
         category = 'error' if 'invalide' in str(exc).lower() or 'introuvable' in str(exc).lower() else 'warning'
         flash(str(exc), category)

--- a/services/race_service.py
+++ b/services/race_service.py
@@ -208,7 +208,7 @@ def _get_open_race_for_slot(scheduled_at):
     return Race.query.filter_by(scheduled_at=scheduled_at, status='open').first()
 
 
-def plan_pig_for_race(user_id, pig_id, scheduled_at_raw, strategy):
+def plan_pig_for_race(user_id, pig_id, scheduled_at_raw, strategy_profile):
     pig = Pig.query.filter_by(id=pig_id, user_id=user_id, is_alive=True).first()
     if not pig:
         raise PigNotFoundError("Cochon introuvable pour cette planification.")
@@ -246,7 +246,18 @@ def plan_pig_for_race(user_id, pig_id, scheduled_at_raw, strategy):
     if count_pig_weekly_course_commitments(pig.id, scheduled_at) >= WEEKLY_RACE_QUOTA:
         raise WeeklyQuotaReachedError(f"{pig.name} a deja atteint son quota hebdomadaire de {WEEKLY_RACE_QUOTA} courses.")
 
-    db.session.add(CoursePlan(user_id=user_id, pig_id=pig.id, scheduled_at=scheduled_at, strategy=int(strategy)))
+    db.session.add(
+        CoursePlan(
+            user_id=user_id,
+            pig_id=pig.id,
+            scheduled_at=scheduled_at,
+            strategy_profile=CoursePlan.build_strategy_profile(
+                phase_1=strategy_profile['phase_1'],
+                phase_2=strategy_profile['phase_2'],
+                phase_3=strategy_profile['phase_3'],
+            ),
+        )
+    )
     db.session.flush()
 
     if open_race:
@@ -316,7 +327,17 @@ def populate_race_participants(race, respect_course_plans=True, allow_rebuild_if
         all_powers.append(power)
         owner = User.query.get(pig.user_id)
         plan = CoursePlan.query.filter_by(pig_id=pig.id, scheduled_at=race.scheduled_at).first()
-        participant = Participant(race_id=race.id, name=pig.name, emoji=pig.emoji, pig_id=pig.id, owner_name=owner.username if owner else None, strategy=plan.strategy if plan else 50, odds=0, win_probability=0)
+        plan_profile = plan.strategy_segments if plan else {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
+        participant = Participant(
+            race_id=race.id,
+            name=pig.name,
+            emoji=pig.emoji,
+            pig_id=pig.id,
+            owner_name=owner.username if owner else None,
+            strategy=plan_profile['phase_1'],
+            odds=0,
+            win_probability=0,
+        )
         db.session.add(participant)
         participants_list.append(participant)
     player_names = {pig.name for pig in fit_pigs}
@@ -373,9 +394,7 @@ def build_course_schedule(user, pigs, days=30):
         for pig in pigs:
             is_actual_participant = pig.id in slot_actual_pig_ids
             is_planned = pig.id in slot_user_plan_by_pig
-            current_strategy = next((p.strategy for p in slot_participants if p.pig_id == pig.id), None) if is_actual_participant else None
-            if current_strategy is None:
-                current_strategy = slot_user_plan_by_pig[pig.id].strategy if is_planned else 50
+            current_strategy = slot_user_plan_by_pig[pig.id].strategy_segments if is_planned else {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
             exclude_slot = slot_time if (is_actual_participant or is_planned) else None
             weekly_commitments = count_pig_weekly_course_commitments(pig.id, slot_time, exclude_scheduled_at=exclude_slot)
             projected_commitments = weekly_commitments + (0 if (is_actual_participant or is_planned) else 1)
@@ -387,6 +406,6 @@ def build_course_schedule(user, pigs, days=30):
                 can_toggle, disabled_reason = False, 'Trop faible pour la course ouverte'
             elif quota_reached:
                 can_toggle, disabled_reason = False, 'Quota hebdo atteint'
-            pig_options.append({'pig': pig, 'is_planned': is_planned, 'is_actual_participant': is_actual_participant, 'current_strategy': current_strategy, 'can_toggle': can_toggle, 'disabled_reason': disabled_reason, 'weekly_commitments': projected_commitments, 'quota_remaining': max(0, WEEKLY_RACE_QUOTA - weekly_commitments), 'projected_remaining': max(0, WEEKLY_RACE_QUOTA - projected_commitments)})
+            pig_options.append({'pig': pig, 'is_planned': is_planned, 'is_actual_participant': is_actual_participant, 'current_strategy_profile': current_strategy, 'current_strategy_summary': f"D {current_strategy['phase_1']} • M {current_strategy['phase_2']} • F {current_strategy['phase_3']}", 'can_toggle': can_toggle, 'disabled_reason': disabled_reason, 'weekly_commitments': projected_commitments, 'quota_remaining': max(0, WEEKLY_RACE_QUOTA - weekly_commitments), 'projected_remaining': max(0, WEEKLY_RACE_QUOTA - projected_commitments)})
         schedule.append({'slot': slot_time, 'slot_key': slot_time.strftime('%Y-%m-%dT%H:%M:%S'), 'day_name': JOURS_FR[slot_time.weekday()], 'theme': get_course_theme(slot_time), 'race': race, 'participants': slot_participants, 'planned_count': len(slot_plan_rows), 'user_plans': slot_user_plans, 'user_plan_names': [plan.pig.name for plan in slot_user_plans if plan.pig], 'is_next': slot_time == slots[0], 'is_locked': slot_locked, 'pig_options': pig_options, 'user_weekly_plan_count': len(slot_user_plans), 'user_weekly_remaining': {pig.id: max(0, WEEKLY_RACE_QUOTA - count_pig_weekly_course_commitments(pig.id, slot_time)) for pig in pigs}})
     return schedule

--- a/templates/courses.html
+++ b/templates/courses.html
@@ -82,6 +82,22 @@
             background: rgba(255, 232, 240, 0.04);
         }
         .table-shell tr:last-child td { border-bottom: none; }
+        .pig-live-preview {
+            transition: filter 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
+        }
+        .pig-live-preview[data-live-event="sprint"] {
+            filter: drop-shadow(0 0 0.65rem rgba(250, 204, 21, 0.75));
+            transform: scale(1.06);
+        }
+        .pig-live-preview[data-live-event="tired"] {
+            opacity: 0.7;
+        }
+        .pig-live-preview[data-live-event="stumble"] {
+            filter: grayscale(0.2) drop-shadow(0 0 0.45rem rgba(248, 113, 113, 0.7));
+        }
+        .pig-live-preview[data-is-drafting="true"] {
+            filter: drop-shadow(0 0 0.55rem rgba(34, 211, 238, 0.65));
+        }
     </style>
 </head>
 <body>
@@ -286,16 +302,29 @@
                             <form method="POST" action="/courses/plan">
                                 <input type="hidden" name="pig_id" value="{{ pig.id }}">
                                 <input type="hidden" name="scheduled_at" value="{{ slot.slot_key }}">
-                                
-                                <div class="mb-3 px-1">
-                                    <div class="flex justify-between text-[10px] font-bold text-white/40 uppercase mb-1">
-                                        <span>🐢 Éco</span>
-                                        <span class="text-white/60">Stratégie: {{ option.current_strategy }}%</span>
-                                        <span>Attaque 🚀</span>
+                                <div class="mb-3 px-1 space-y-3">
+                                    <div class="flex items-center justify-between">
+                                        <div>
+                                            <p class="text-[10px] font-bold text-white/40 uppercase">Plan Flamme Rouge</p>
+                                            <p class="text-xs text-white/60 font-semibold">{{ option.current_strategy_summary }}</p>
+                                        </div>
+                                        <span class="pig-live-preview text-2xl" data-live-event="sprint" data-is-drafting="true">{{ pig.emoji }}</span>
                                     </div>
-                                    <input type="range" name="strategy" min="0" max="100" value="{{ option.current_strategy }}" 
-                                           class="w-full accent-pink-500 bg-white/10 rounded-lg appearance-none h-1.5 cursor-pointer"
-                                           oninput="this.previousElementSibling.querySelector('.text-white\\/60').innerText = 'Stratégie: ' + this.value + '%'">
+                                    <div class="grid grid-cols-3 gap-2 text-xs">
+                                        {% set profile = option.current_strategy_profile %}
+                                        {% set labels = [('strategy_phase_1', 'Départ', profile.phase_1), ('strategy_phase_2', 'Milieu', profile.phase_2), ('strategy_phase_3', 'Final', profile.phase_3)] %}
+                                        {% for field_name, phase_label, current_value in labels %}
+                                        <label class="soft-card p-2 block">
+                                            <span class="text-white/55 font-bold uppercase tracking-wide text-[10px]">{{ phase_label }}</span>
+                                            <select name="{{ field_name }}" class="mt-2 w-full rounded-lg bg-white/10 border border-white/10 text-white text-sm font-bold px-2 py-2">
+                                                <option value="35" {% if current_value == 35 %}selected{% endif %}>Économie</option>
+                                                <option value="50" {% if current_value == 50 %}selected{% endif %}>Neutre</option>
+                                                <option value="85" {% if current_value == 85 %}selected{% endif %}>Attaque</option>
+                                            </select>
+                                        </label>
+                                        {% endfor %}
+                                    </div>
+                                    <p class="text-[11px] text-white/40 font-semibold">Prévu pour le live replay : halo sprint, opacité fatigue, et aspiration visible via les flags JSON.</p>
                                 </div>
 
                                 <button type="submit" class="btn-plan


### PR DESCRIPTION
### Motivation
- Allow per-race three-phase (“Flamme Rouge”) planning so players can set Départ/Milieu/Final intensities instead of a single integer strategy. 
- Provide richer live replay telemetry for frontend animation and enable trophies based on post-mortem career analysis.

### Description
- Replaced single `CoursePlan.strategy` with `CoursePlan.strategy_profile` (JSON text), added `build_strategy_profile`, `strategy_segments`, and `strategy_summary` helpers, and changed plan storage to the JSON profile (see `models.py`).
- Race participant simulation now carries a `strategy_profile` and `CourseManager` computes a `track_profile`, resolves the active phase by segment index and updates `p.strategy` dynamically per turn; `to_json()` now emits `{track_profile, segments, turns}` (see `race_engine.py`).
- Planning flow updated: `routes/race.py` reads `strategy_phase_1/2/3` from the form, `services/race_service.py` stores the profile and pre-fills participants with the phase_1 starting strategy, and `helpers.py`/`populate_race_participants` were synchronized to use the profile (see `routes/race.py`, `services/race_service.py`, `helpers.py`).
- Replay telemetry extended: `record_history` now includes `is_drafting`, `strategy`, and `visual_event` (`stumble`, `sprint`, `tired`) for frontend use; `templates/courses.html` adds the 3-phase UI selectors and preview CSS styles for live flags.
- Trophy model extended with `trophy_key` and `date_earned`, and `Pig.maybe_award_memorial_trophies` now awards the requested trophies ("L'Ancien du Bureau", "Expert des Segments", "Mémoire de Fer") using winners’ `replay_json`; a small DB migration/backfill was added to `app.py` to populate new columns.

### Testing
- Compiled modules with `python -m compileall app.py models.py race_engine.py routes/race.py services/race_service.py helpers.py` and compilation succeeded.
- Ran a small simulation script that builds a profile with `CoursePlan.build_strategy_profile(...)`, created a `CourseManager` with a test participant, executed `simulate_turn()` / `record_history()` and printed `manager.to_json()` to validate the new payload; the output contained `track_profile`, `segments` and `turns` including `is_drafting`, `strategy` and `visual_event` (run completed successfully).
- No UI integration tests were run here; CSS/HTML changes prepare the frontend to interpret the new flags but full browser verification was not performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf22d402bc8323a62de07c5529e98f)