### PR TITLE
Refine tactical segmented race simulation

### DIFF
--- a/data.py
+++ b/data.py
@@ -410,51 +410,59 @@ PIG_COURSE_SEGMENT_TYPES = ['PLAT', 'MONTEE', 'DESCENTE', 'VIRAGE', 'BOUE']
 # Limite de tours pour eviter une boucle infinie
 RACE_MAX_TURNS = 500
 
+# -- Strategie --
+RACE_ATTACK_THRESHOLD = 71
+RACE_NEUTRAL_MAX = 70
+RACE_STRATEGY_ECONOMY_MIN_MULT = 0.72
+RACE_STRATEGY_ATTACK_MAX_MULT = 1.18
+RACE_STRATEGY_ECONOMY_RECOVERY = 2.2
+RACE_STRATEGY_NEUTRAL_FATIGUE = 1.2
+RACE_ATTACK_FATIGUE_EXPONENT = 1.6
+
 # -- Vitesse de base --
-RACE_BASE_SPEED_VIT_MULT = 0.2       # coefficient de vitesse dans base_speed (plat)
+RACE_BASE_SPEED_VIT_MULT = 0.75      # coefficient principal sur le plat
 RACE_BASE_SPEED_CONSTANT = 2.0       # plancher additif de base_speed
 RACE_MIN_FINAL_SPEED = 0.5           # vitesse minimale garantie par tour
-
-# -- Strategie --
-RACE_STRATEGY_NEUTRAL = 50           # valeur neutre (pas de bonus/malus)
-RACE_STRATEGY_SPEED_FACTOR = 0.005   # impact de la strategie sur la vitesse par point
-RACE_STRATEGY_FATIGUE_BASE = 1.0     # base de gain de fatigue
-RACE_STRATEGY_FATIGUE_DIVISOR = 50.0 # diviseur pour le calcul du gain fatigue
+RACE_SEGMENT_SPEED_CAP = 30.0        # plafond de vitesse sur terrain libre
+RACE_VIRAGE_SPEED_CAP = 18.0         # plafond dans les virages
+RACE_BOUE_SPEED_CAP = 14.0           # plafond dans la boue
 
 # -- Fatigue --
-RACE_FATIGUE_SPEED_PENALTY_FLOOR = 0.4    # malus de vitesse minimum (40% de speed restant)
-RACE_FATIGUE_SPEED_PENALTY_DIVISOR = 100.0  # diviseur pour le calcul du malus
-RACE_ECONOMY_THRESHOLD = 25               # strat en dessous de ce seuil = mode economie
-RACE_ECONOMY_FATIGUE_RECOVERY = 0.1       # recuperation de fatigue par tour en mode economie
+RACE_FATIGUE_SPEED_PENALTY_FLOOR = 0.4
+RACE_FATIGUE_SPEED_PENALTY_DIVISOR = 100.0
+RACE_ENDURANCE_FATIGUE_DIVISOR = 1.0
+RACE_RECENT_RACE_PENALTY_FLOOR = 0.88
 
 # -- Terrain : MONTEE --
-RACE_MONTEE_VIT_MULT = 0.1           # part de vitesse en montee
-RACE_MONTEE_FORCE_MULT = 0.1         # part de force en montee
-RACE_MONTEE_TERRAIN_MOD = 0.8        # modificateur terrain montee
+RACE_MONTEE_SPEED_MULT = 0.8
+RACE_MONTEE_FORCE_MULT = 1.2
+RACE_MONTEE_TERRAIN_MOD = 0.86
 
 # -- Terrain : DESCENTE --
-RACE_DESCENTE_TERRAIN_MOD = 1.4      # modificateur terrain descente
-RACE_DESCENTE_STUMBLE_AGI_REF = 40   # seuil d'agilite pour risque de chute
-RACE_DESCENTE_STUMBLE_AGI_DIV = 200.0  # diviseur risque agilite
-RACE_DESCENTE_STUMBLE_CHANCE_DIV = 500.0  # diviseur chance (reduit le risque)
-RACE_STUMBLE_SPEED_MULT = 0.3       # multiplicateur vitesse en cas de chute
+RACE_DESCENTE_SPEED_MULT = 0.95
+RACE_DESCENTE_TERRAIN_MOD = 1.08
+RACE_DESCENTE_AGI_RISK_REDUCTION = 140.0
+RACE_STUMBLE_BASE_CHANCE_DESCENTE = 0.12
+RACE_STUMBLE_SPEED_MULT = 0.5
 
 # -- Terrain : VIRAGE / BOUE --
-RACE_VIRAGE_VIT_MULT = 0.05          # part de vitesse en virage/boue
-RACE_VIRAGE_AGI_MULT = 0.15          # part d'agilite en virage/boue
-RACE_VIRAGE_TERRAIN_MOD = 0.9        # modificateur terrain virage
-RACE_BOUE_TERRAIN_MOD = 0.7          # modificateur terrain boue
+RACE_STUMBLE_BASE_CHANCE_VIRAGE = 0.09
+RACE_VIRAGE_AGI_MULT = 0.9
+RACE_VIRAGE_TERRAIN_MOD = 0.88
+RACE_BOUE_AGI_MULT = 0.75
+RACE_BOUE_TERRAIN_MOD = 0.76
 
 # -- Aspiration (Drafting) --
-RACE_DRAFT_MIN_DIST = 0.5            # distance min pour declencher l'aspiration
-RACE_DRAFT_MAX_DIST = 4.0            # distance max pour declencher l'aspiration
-RACE_DRAFT_BASE_CHANCE = 0.7         # probabilite de base d'aspiration
-RACE_DRAFT_STRATEGY_FACTOR = 0.003   # bonus de chance par point d'economie
-RACE_DRAFT_SPEED_BONUS = 0.8         # boost de vitesse en aspiration
+RACE_DRAFT_MIN_DIST = 1.0
+RACE_DRAFT_MAX_DIST = 3.0
+RACE_DRAFT_BONUS_MIN = 0.8
+RACE_DRAFT_BONUS_MAX = 1.8
+RACE_DRAFT_NO_FATIGUE_BONUS = 1.8
+RACE_FATIGUE_HEADWIND_PENALTY = 0.8
 
 # -- Variance --
-RACE_VARIANCE_MIN = 0.95             # borne basse du facteur aleatoire
-RACE_VARIANCE_MAX = 1.05             # borne haute du facteur aleatoire
+RACE_VARIANCE_MIN = 0.98
+RACE_VARIANCE_MAX = 1.02
 
 # ---------------------------------------------------------------------------
 # Bourse aux Grains -- marche dynamique de cereales

--- a/helpers.py
+++ b/helpers.py
@@ -1368,6 +1368,13 @@ def run_race_if_needed():
                     pig_comeback_bonus_flags[p.pig_id] = bool(pig.comeback_bonus_ready)
                     plan = CoursePlan.query.filter_by(pig_id=pig.id, scheduled_at=race.scheduled_at).first()
                     strategy_profile = plan.strategy_segments if plan else {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
+                    last_race_at = get_pig_last_race_datetime(pig)
+                    hours_since_last_race = ((race.scheduled_at - last_race_at).total_seconds() / 3600.0) if last_race_at else 999.0
+                    recent_race_penalty_multiplier = 1.0
+                    if hours_since_last_race < 24:
+                        recent_race_penalty_multiplier = 0.9
+                    elif hours_since_last_race < 48:
+                        recent_race_penalty_multiplier = 0.95
                     pigs_for_sim.append({
                         'id': pig.id, 'name': pig.name, 'emoji': pig.emoji,
                         'vitesse': pig.vitesse, 'endurance': pig.endurance, 'force': pig.force, 'agilite': pig.agilite,
@@ -1375,6 +1382,7 @@ def run_race_if_needed():
                         'strategy_profile': strategy_profile,
                         'freshness': pig.freshness, 'is_happy': (pig.freshness or 0) > 90.0,
                         'speed_bonus_multiplier': 1.1 if pig.comeback_bonus_ready else 1.0,
+                        'recent_race_penalty_multiplier': recent_race_penalty_multiplier,
                     })
                 else:
                     # Mock NPC pig stats based on odds

--- a/race_engine.py
+++ b/race_engine.py
@@ -1,41 +1,63 @@
-import random
 import json
-import math
-from dataclasses import dataclass, field, asdict
+import random
+from dataclasses import dataclass, field
 from typing import Optional
 
 from data import (
+    RACE_ATTACK_FATIGUE_EXPONENT,
+    RACE_ATTACK_THRESHOLD,
+    RACE_BASE_SPEED_CONSTANT,
+    RACE_BOUE_AGI_MULT,
+    RACE_BOUE_SPEED_CAP,
+    RACE_BOUE_TERRAIN_MOD,
+    RACE_DRAFT_BONUS_MAX,
+    RACE_DRAFT_BONUS_MIN,
+    RACE_DRAFT_MAX_DIST,
+    RACE_DRAFT_MIN_DIST,
+    RACE_DRAFT_NO_FATIGUE_BONUS,
+    RACE_ENDURANCE_FATIGUE_DIVISOR,
+    RACE_FATIGUE_HEADWIND_PENALTY,
+    RACE_FATIGUE_SPEED_PENALTY_DIVISOR,
+    RACE_FATIGUE_SPEED_PENALTY_FLOOR,
     RACE_MAX_TURNS,
-    RACE_BASE_SPEED_VIT_MULT, RACE_BASE_SPEED_CONSTANT, RACE_MIN_FINAL_SPEED,
-    RACE_STRATEGY_NEUTRAL, RACE_STRATEGY_SPEED_FACTOR,
-    RACE_STRATEGY_FATIGUE_BASE, RACE_STRATEGY_FATIGUE_DIVISOR,
-    RACE_FATIGUE_SPEED_PENALTY_FLOOR, RACE_FATIGUE_SPEED_PENALTY_DIVISOR,
-    RACE_ECONOMY_THRESHOLD, RACE_ECONOMY_FATIGUE_RECOVERY,
-    RACE_MONTEE_VIT_MULT, RACE_MONTEE_FORCE_MULT, RACE_MONTEE_TERRAIN_MOD,
-    RACE_DESCENTE_TERRAIN_MOD, RACE_DESCENTE_STUMBLE_AGI_REF,
-    RACE_DESCENTE_STUMBLE_AGI_DIV, RACE_DESCENTE_STUMBLE_CHANCE_DIV,
+    RACE_MIN_FINAL_SPEED,
+    RACE_MONTEE_FORCE_MULT,
+    RACE_MONTEE_SPEED_MULT,
+    RACE_MONTEE_TERRAIN_MOD,
+    RACE_NEUTRAL_MAX,
+    RACE_RECENT_RACE_PENALTY_FLOOR,
+    RACE_SEGMENT_SPEED_CAP,
+    RACE_STUMBLE_BASE_CHANCE_DESCENTE,
+    RACE_STUMBLE_BASE_CHANCE_VIRAGE,
     RACE_STUMBLE_SPEED_MULT,
-    RACE_VIRAGE_VIT_MULT, RACE_VIRAGE_AGI_MULT,
-    RACE_VIRAGE_TERRAIN_MOD, RACE_BOUE_TERRAIN_MOD,
-    RACE_DRAFT_MIN_DIST, RACE_DRAFT_MAX_DIST,
-    RACE_DRAFT_BASE_CHANCE, RACE_DRAFT_STRATEGY_FACTOR, RACE_DRAFT_SPEED_BONUS,
-    RACE_VARIANCE_MIN, RACE_VARIANCE_MAX,
+    RACE_STRATEGY_ATTACK_MAX_MULT,
+    RACE_STRATEGY_ECONOMY_MIN_MULT,
+    RACE_STRATEGY_ECONOMY_RECOVERY,
+    RACE_STRATEGY_NEUTRAL_FATIGUE,
+    RACE_VARIANCE_MAX,
+    RACE_VARIANCE_MIN,
+    RACE_VIRAGE_AGI_MULT,
+    RACE_VIRAGE_SPEED_CAP,
+    RACE_VIRAGE_TERRAIN_MOD,
+    RACE_DESCENTE_AGI_RISK_REDUCTION,
+    RACE_DESCENTE_SPEED_MULT,
+    RACE_DESCENTE_TERRAIN_MOD,
 )
+
+DEFAULT_STRATEGY_PROFILE = {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
+
+
+@dataclass(frozen=True)
+class Segment:
+    type: str
+    length: float
 
 
 @dataclass
 class RaceParticipant:
-    """Représentation typée d'un cochon en course.
-
-    Utilisée en interne par CourseManager à la place d'un dictionnaire brut.
-    Les attributs de stats sont en lecture seule pendant la course ; seuls
-    distance, fatigue, has_draft, is_finished, finish_time et stumbled
-    sont mutés par le moteur.
-    """
     id: int
     name: str
     emoji: str
-    # Stats de course (copiées depuis le modèle Pig ou un dict)
     vitesse: float = 10.0
     endurance: float = 10.0
     force: float = 10.0
@@ -43,22 +65,26 @@ class RaceParticipant:
     intelligence: float = 10.0
     moral: float = 10.0
     strategy: int = 50
-    strategy_profile: dict = field(default_factory=lambda: {'phase_1': 35, 'phase_2': 50, 'phase_3': 80})
+    strategy_profile: dict = field(default_factory=lambda: DEFAULT_STRATEGY_PROFILE.copy())
     freshness: float = 100.0
     is_happy: bool = False
     speed_bonus_multiplier: float = 1.0
-    # État mutable pendant la simulation
+    recent_race_penalty_multiplier: float = 1.0
     distance: float = 0.0
     fatigue: float = 0.0
     has_draft: bool = False
+    draft_bonus: float = 0.0
+    skip_fatigue_this_turn: bool = False
     is_finished: bool = False
     finish_time: Optional[int] = None
     stumbled: bool = False
+    current_speed: float = 0.0
+    current_segment_type: str = 'PLAT'
+    current_phase: str = 'phase_1'
+    visual_event: Optional[str] = None
 
     @classmethod
     def from_source(cls, source) -> 'RaceParticipant':
-        """Construit un RaceParticipant depuis un objet SQLAlchemy (Pig/Participant)
-        ou un dictionnaire brut. Gère les deux cas de manière transparente."""
         def _get(key, default=10):
             if hasattr(source, key):
                 return getattr(source, key)
@@ -66,15 +92,24 @@ class RaceParticipant:
                 return source.get(key, default)
             return default
 
-        strategy_profile = _get('strategy_profile', {'phase_1': 35, 'phase_2': 50, 'phase_3': 80})
+        strategy_profile = _get('strategy_profile', DEFAULT_STRATEGY_PROFILE)
         if isinstance(strategy_profile, str):
             try:
                 strategy_profile = json.loads(strategy_profile)
             except (TypeError, ValueError):
-                strategy_profile = {'phase_1': 35, 'phase_2': 50, 'phase_3': 80}
+                strategy_profile = DEFAULT_STRATEGY_PROFILE
+
+        strategy_profile = {
+            'phase_1': int(strategy_profile.get('phase_1', DEFAULT_STRATEGY_PROFILE['phase_1'])),
+            'phase_2': int(strategy_profile.get('phase_2', DEFAULT_STRATEGY_PROFILE['phase_2'])),
+            'phase_3': int(strategy_profile.get('phase_3', DEFAULT_STRATEGY_PROFILE['phase_3'])),
+        }
+
+        recent_penalty = float(_get('recent_race_penalty_multiplier', 1.0) or 1.0)
+        recent_penalty = max(RACE_RECENT_RACE_PENALTY_FLOOR, min(1.0, recent_penalty))
 
         return cls(
-            id=_get('id', 0),
+            id=int(_get('id', 0)),
             name=_get('name', 'Inconnu'),
             emoji=_get('emoji', '🐷'),
             vitesse=float(_get('vitesse', 10)),
@@ -88,193 +123,242 @@ class RaceParticipant:
             freshness=float(_get('freshness', 100.0)),
             is_happy=bool(_get('is_happy', float(_get('freshness', 100.0)) > 90.0)),
             speed_bonus_multiplier=float(_get('speed_bonus_multiplier', 1.0)),
+            recent_race_penalty_multiplier=recent_penalty,
         )
 
 
 class CourseManager:
-    """
-    Simulateur de course de cochons 'Derby des Groins'
-    Inspiré par le système tactique de 'Flamme Rouge'.
-
-    Toutes les constantes d'équilibrage sont définies dans data.py
-    (préfixe RACE_*) pour faciliter le tuning.
-    Les participants sont des instances de RaceParticipant (dataclass).
-    """
-
-    def __init__(self, participants, segments):
-        """
-        :param participants: Liste d'objets (Pig, Participant) ou dicts.
-        :param segments: Liste de dicts {'type': 'PLAT', 'length': 100}
-        """
-        self.participants: list[RaceParticipant] = [
-            RaceParticipant.from_source(p) for p in participants
-        ]
-        self.segments = segments
-        self.total_length = sum(s['length'] for s in segments)
+    def __init__(self, participants, segments, rng: Optional[random.Random] = None):
+        self.participants: list[RaceParticipant] = [RaceParticipant.from_source(p) for p in participants]
+        self.segments: list[Segment] = [Segment(type=s.get('type', 'PLAT'), length=float(s.get('length', 0))) for s in segments]
+        self.total_length = sum(segment.length for segment in self.segments)
         self.history: list[dict] = []
         self.current_turn: int = 0
+        self.rng = rng or random.Random()
         self.track_profile = self._compute_track_profile()
 
     def _compute_track_profile(self) -> str:
         terrain_lengths = {}
-        for seg in self.segments:
-            seg_type = seg.get('type', 'PLAT')
-            terrain_lengths[seg_type] = terrain_lengths.get(seg_type, 0) + seg.get('length', 0)
-        filtered = {k: v for k, v in terrain_lengths.items() if k != 'PLAT'}
-        profile_source = filtered or terrain_lengths or {'PLAT': 0}
+        for segment in self.segments:
+            terrain_lengths[segment.type] = terrain_lengths.get(segment.type, 0.0) + segment.length
+        filtered = {key: value for key, value in terrain_lengths.items() if key != 'PLAT'}
+        profile_source = filtered or terrain_lengths or {'PLAT': 0.0}
         return max(profile_source, key=profile_source.get)
 
-    def _resolve_phase_strategy(self, participant: RaceParticipant, segment_index: int) -> int:
-        total_segments = max(1, len(self.segments))
-        phase_step = total_segments / 3
-        if segment_index < phase_step:
+    def _locate_segment(self, distance: float) -> tuple[int, Segment]:
+        covered = 0.0
+        for index, segment in enumerate(self.segments):
+            covered += segment.length
+            if distance < covered:
+                return index, segment
+        return len(self.segments) - 1, self.segments[-1]
+
+    def _resolve_phase_strategy(self, participant: RaceParticipant) -> tuple[str, int]:
+        progress_ratio = 0.0 if self.total_length <= 0 else participant.distance / self.total_length
+        if progress_ratio < 1 / 3:
             phase_key = 'phase_1'
-        elif segment_index < phase_step * 2:
+        elif progress_ratio < 2 / 3:
             phase_key = 'phase_2'
         else:
             phase_key = 'phase_3'
-        profile = participant.strategy_profile or {}
-        return int(profile.get(phase_key, participant.strategy))
+        strategy_value = int(participant.strategy_profile.get(phase_key, participant.strategy))
+        return phase_key, max(0, min(100, strategy_value))
+
+    def _strategy_speed_multiplier(self, strategy: int) -> float:
+        if strategy <= 30:
+            ratio = strategy / 30.0 if strategy else 0.0
+            return RACE_STRATEGY_ECONOMY_MIN_MULT + ((1.0 - RACE_STRATEGY_ECONOMY_MIN_MULT) * ratio)
+        if strategy <= RACE_NEUTRAL_MAX:
+            return 0.97 + (((strategy - 30) / max(1, RACE_NEUTRAL_MAX - 30)) * 0.03)
+        ratio = (strategy - RACE_NEUTRAL_MAX) / max(1, 100 - RACE_NEUTRAL_MAX)
+        return 1.0 + ((RACE_STRATEGY_ATTACK_MAX_MULT - 1.0) * ratio)
+
+    def _fatigue_delta(self, participant: RaceParticipant, strategy: int) -> float:
+        if participant.skip_fatigue_this_turn:
+            return -RACE_DRAFT_NO_FATIGUE_BONUS
+        if strategy <= 30:
+            recovery_scale = (30 - strategy) / 30.0
+            return -(RACE_STRATEGY_ECONOMY_RECOVERY * max(0.2, recovery_scale))
+        if strategy <= RACE_NEUTRAL_MAX:
+            return RACE_STRATEGY_NEUTRAL_FATIGUE + (strategy - 30) / 80.0
+        attack_ratio = (strategy - RACE_NEUTRAL_MAX) / max(1, 100 - RACE_NEUTRAL_MAX)
+        return RACE_STRATEGY_NEUTRAL_FATIGUE + (attack_ratio ** RACE_ATTACK_FATIGUE_EXPONENT) * 8.0
+
+    def _fatigue_speed_penalty(self, participant: RaceParticipant) -> float:
+        endurance_buffer = participant.endurance * RACE_ENDURANCE_FATIGUE_DIVISOR
+        if participant.fatigue <= endurance_buffer:
+            return 1.0
+        excess = participant.fatigue - endurance_buffer
+        return max(
+            RACE_FATIGUE_SPEED_PENALTY_FLOOR,
+            1.0 - (excess / RACE_FATIGUE_SPEED_PENALTY_DIVISOR),
+        )
+
+    def _segment_speed_profile(self, participant: RaceParticipant, segment: Segment) -> tuple[float, float, float, float]:
+        terrain_mod = 1.0
+        speed_cap = RACE_SEGMENT_SPEED_CAP
+        stumble_chance = 0.0
+
+        if segment.type == 'MONTEE':
+            base_speed = (
+                participant.vitesse * RACE_MONTEE_SPEED_MULT
+                + participant.force * RACE_MONTEE_FORCE_MULT
+                + RACE_BASE_SPEED_CONSTANT
+            )
+            terrain_mod = RACE_MONTEE_TERRAIN_MOD
+        elif segment.type == 'DESCENTE':
+            base_speed = (
+                participant.vitesse * RACE_DESCENTE_SPEED_MULT
+                + participant.agilite * 0.35
+                + RACE_BASE_SPEED_CONSTANT
+            )
+            terrain_mod = RACE_DESCENTE_TERRAIN_MOD
+            stumble_chance = max(
+                0.0,
+                RACE_STUMBLE_BASE_CHANCE_DESCENTE - (participant.agilite / RACE_DESCENTE_AGI_RISK_REDUCTION),
+            )
+        elif segment.type == 'VIRAGE':
+            base_speed = (
+                participant.vitesse * 0.35
+                + participant.agilite * RACE_VIRAGE_AGI_MULT
+                + participant.intelligence * 0.12
+                + RACE_BASE_SPEED_CONSTANT
+            )
+            terrain_mod = RACE_VIRAGE_TERRAIN_MOD
+            speed_cap = RACE_VIRAGE_SPEED_CAP
+            stumble_chance = max(0.0, RACE_STUMBLE_BASE_CHANCE_VIRAGE - (participant.agilite / 220.0))
+        elif segment.type == 'BOUE':
+            base_speed = (
+                participant.force * 0.45
+                + participant.agilite * RACE_BOUE_AGI_MULT
+                + participant.vitesse * 0.20
+                + RACE_BASE_SPEED_CONSTANT
+            )
+            terrain_mod = RACE_BOUE_TERRAIN_MOD
+            speed_cap = RACE_BOUE_SPEED_CAP
+        else:
+            base_speed = participant.vitesse * 0.75 + participant.endurance * 0.20 + RACE_BASE_SPEED_CONSTANT
+
+        return base_speed, terrain_mod, min(0.45, stumble_chance), speed_cap
+
+    def _leading_participant(self) -> Optional[RaceParticipant]:
+        active = [participant for participant in self.participants if not participant.is_finished]
+        return max(active, key=lambda participant: participant.distance, default=None)
+
+    def _apply_drafting_for_next_turn(self):
+        sorted_pigs = sorted(self.participants, key=lambda participant: participant.distance, reverse=True)
+        leader = sorted_pigs[0] if sorted_pigs else None
+        for participant in sorted_pigs:
+            participant.has_draft = False
+            participant.draft_bonus = 0.0
+            participant.skip_fatigue_this_turn = False
+
+        for index in range(1, len(sorted_pigs)):
+            front = sorted_pigs[index - 1]
+            chaser = sorted_pigs[index]
+            distance_gap = front.distance - chaser.distance
+            if RACE_DRAFT_MIN_DIST <= distance_gap <= RACE_DRAFT_MAX_DIST:
+                closeness_ratio = 1.0 - ((distance_gap - RACE_DRAFT_MIN_DIST) / max(0.01, RACE_DRAFT_MAX_DIST - RACE_DRAFT_MIN_DIST))
+                chaser.has_draft = True
+                chaser.draft_bonus = RACE_DRAFT_BONUS_MIN + ((RACE_DRAFT_BONUS_MAX - RACE_DRAFT_BONUS_MIN) * closeness_ratio)
+                chaser.skip_fatigue_this_turn = True
+
+        if leader and not leader.is_finished:
+            leader.fatigue += RACE_FATIGUE_HEADWIND_PENALTY
 
     def run(self):
-        """Lance la simulation complète."""
-        while not all(p.is_finished for p in self.participants) and self.current_turn < RACE_MAX_TURNS:
+        while not all(participant.is_finished for participant in self.participants) and self.current_turn < RACE_MAX_TURNS:
             self.current_turn += 1
             self.simulate_turn()
             self.record_history()
-
         return self.history
 
     def simulate_turn(self):
-        for p in self.participants:
-            if p.is_finished:
+        for participant in self.participants:
+            if participant.is_finished:
+                participant.current_speed = 0.0
+                participant.visual_event = 'finished'
                 continue
 
-            # Find current segment
-            temp_dist = 0
-            current_seg = self.segments[-1]
-            current_seg_index = len(self.segments) - 1
-            for seg_index, seg in enumerate(self.segments):
-                temp_dist += seg['length']
-                if p.distance < temp_dist:
-                    current_seg = seg
-                    current_seg_index = seg_index
-                    break
+            phase_key, strategy_value = self._resolve_phase_strategy(participant)
+            participant.current_phase = phase_key
+            participant.strategy = strategy_value
+            _, segment = self._locate_segment(participant.distance)
+            participant.current_segment_type = segment.type
 
-            p.strategy = self._resolve_phase_strategy(p, current_seg_index)
+            base_speed, terrain_mod, stumble_chance, speed_cap = self._segment_speed_profile(participant, segment)
+            strategy_mult = self._strategy_speed_multiplier(strategy_value)
+            fatigue_penalty = self._fatigue_speed_penalty(participant)
+            freshness_factor = 0.88 + (max(0.0, min(100.0, participant.freshness)) / 833.0)
+            variance = self.rng.uniform(RACE_VARIANCE_MIN, RACE_VARIANCE_MAX)
 
-            progression = self.calculate_progression(p, current_seg)
-            p.distance += progression
+            final_speed = (
+                base_speed
+                * strategy_mult
+                * terrain_mod
+                * fatigue_penalty
+                * freshness_factor
+                * participant.speed_bonus_multiplier
+                * participant.recent_race_penalty_multiplier
+                * variance
+            )
 
-            if p.distance >= self.total_length:
-                p.is_finished = True
-                p.distance = self.total_length
-                p.finish_time = self.current_turn
+            if participant.has_draft:
+                final_speed += participant.draft_bonus
 
-        # Calculate Aspiration (Drafting) for next turn
-        sorted_pigs = sorted(self.participants, key=lambda x: x.distance, reverse=True)
-        for i in range(len(sorted_pigs)):
-            sorted_pigs[i].has_draft = False
-            if i > 0:
-                dist_diff = sorted_pigs[i-1].distance - sorted_pigs[i].distance
-                if RACE_DRAFT_MIN_DIST < dist_diff < RACE_DRAFT_MAX_DIST:
-                    draft_chance = RACE_DRAFT_BASE_CHANCE + (100 - sorted_pigs[i].strategy) * RACE_DRAFT_STRATEGY_FACTOR
-                    if random.random() < draft_chance:
-                        sorted_pigs[i].has_draft = True
+            participant.stumbled = False
+            if segment.type in {'DESCENTE', 'VIRAGE'} and self.rng.random() < stumble_chance:
+                final_speed *= RACE_STUMBLE_SPEED_MULT
+                participant.stumbled = True
 
-    def calculate_progression(self, p: RaceParticipant, segment: dict) -> float:
-        vit = p.vitesse
-        end = p.endurance
-        frc = p.force
-        agi = p.agilite
-        strat = p.strategy
-        chance = (p.intelligence + p.moral) / 2.0
+            final_speed = max(RACE_MIN_FINAL_SPEED, min(speed_cap, final_speed))
+            participant.current_speed = round(final_speed, 3)
+            participant.distance = min(self.total_length, participant.distance + final_speed)
 
-        # 1. Strategy Impact
-        strat_speed_mod = 1.0 + (strat - RACE_STRATEGY_NEUTRAL) * RACE_STRATEGY_SPEED_FACTOR
-        fatigue_gain = RACE_STRATEGY_FATIGUE_BASE + (strat / RACE_STRATEGY_FATIGUE_DIVISOR)
+            fatigue_delta = self._fatigue_delta(participant, strategy_value)
+            participant.fatigue = max(0.0, participant.fatigue + fatigue_delta)
 
-        # 2. Fatigue Malus
-        speed_penalty = 1.0
-        if p.fatigue > end:
-            excess = p.fatigue - end
-            speed_penalty = max(RACE_FATIGUE_SPEED_PENALTY_FLOOR, 1.0 - (excess / RACE_FATIGUE_SPEED_PENALTY_DIVISOR))
+            if participant.distance >= self.total_length:
+                participant.is_finished = True
+                participant.finish_time = self.current_turn
 
-        # 3. Base Speed Calculation
-        base_speed = (vit * RACE_BASE_SPEED_VIT_MULT) + RACE_BASE_SPEED_CONSTANT
+            participant.visual_event = None
+            if participant.stumbled:
+                participant.visual_event = 'stumble'
+            elif participant.has_draft:
+                participant.visual_event = 'drafting'
+            elif strategy_value >= RACE_ATTACK_THRESHOLD:
+                participant.visual_event = 'sprint'
+            elif participant.fatigue > participant.endurance * RACE_ENDURANCE_FATIGUE_DIVISOR:
+                participant.visual_event = 'tired'
 
-        # 4. Terrain Adaptation
-        terrain_mod = 1.0
-        stumble_roll = False
-
-        if segment['type'] == 'MONTEE':
-            base_speed = (vit * RACE_MONTEE_VIT_MULT + frc * RACE_MONTEE_FORCE_MULT) + RACE_BASE_SPEED_CONSTANT
-            terrain_mod = RACE_MONTEE_TERRAIN_MOD
-        elif segment['type'] == 'DESCENTE':
-            terrain_mod = RACE_DESCENTE_TERRAIN_MOD
-            risk = max(0, (RACE_DESCENTE_STUMBLE_AGI_REF - agi) / RACE_DESCENTE_STUMBLE_AGI_DIV) - (chance / RACE_DESCENTE_STUMBLE_CHANCE_DIV)
-            if random.random() < risk:
-                stumble_roll = True
-        elif segment['type'] in ['VIRAGE', 'BOUE']:
-            base_speed = (vit * RACE_VIRAGE_VIT_MULT + agi * RACE_VIRAGE_AGI_MULT) + RACE_BASE_SPEED_CONSTANT
-            terrain_mod = RACE_BOUE_TERRAIN_MOD if segment['type'] == 'BOUE' else RACE_VIRAGE_TERRAIN_MOD
-
-        # 5. Final Speed for this turn
-        freshness_factor = 0.9 + (max(0.0, min(100.0, p.freshness)) / 1000.0)
-        final_speed = base_speed * strat_speed_mod * speed_penalty * terrain_mod * freshness_factor * p.speed_bonus_multiplier
-
-        # 6. Apply stumble
-        if stumble_roll:
-            final_speed *= RACE_STUMBLE_SPEED_MULT
-            p.stumbled = True
-        else:
-            p.stumbled = False
-
-        # 7. Drafting Bonus
-        if p.has_draft and not p.is_finished:
-            final_speed += RACE_DRAFT_SPEED_BONUS
-
-        # 8. Accumulate Fatigue
-        if strat < RACE_ECONOMY_THRESHOLD:
-            p.fatigue = max(0.0, p.fatigue - RACE_ECONOMY_FATIGUE_RECOVERY)
-        else:
-            p.fatigue += fatigue_gain
-
-        # Variance
-        final_speed *= random.uniform(RACE_VARIANCE_MIN, RACE_VARIANCE_MAX)
-
-        return max(RACE_MIN_FINAL_SPEED, final_speed)
+        self._apply_drafting_for_next_turn()
 
     def record_history(self):
-        turn_data = {
+        self.history.append({
             'turn': self.current_turn,
             'pigs': [
                 {
-                    'id': p.id,
-                    'name': p.name,
-                    'distance': round(p.distance, 2),
-                    'fatigue': round(p.fatigue, 1),
-                    'is_finished': p.is_finished,
-                    'stumbled': p.stumbled,
-                    'has_draft': p.has_draft,
-                    'is_drafting': p.has_draft,
-                    'is_happy': p.is_happy,
-                    'strategy': p.strategy,
-                    'visual_event': (
-                        'stumble' if p.stumbled
-                        else 'sprint' if p.strategy > 80
-                        else 'tired' if p.fatigue > p.endurance
-                        else None
-                    ),
+                    'id': participant.id,
+                    'name': participant.name,
+                    'distance': round(participant.distance, 2),
+                    'vitesse_actuelle': round(participant.current_speed, 2),
+                    'fatigue': round(participant.fatigue, 2),
+                    'strategy': participant.strategy,
+                    'phase': participant.current_phase,
+                    'segment_type': participant.current_segment_type,
+                    'is_finished': participant.is_finished,
+                    'has_draft': participant.has_draft,
+                    'stumbled': participant.stumbled,
+                    'visual_event': participant.visual_event,
                 }
-                for p in self.participants
+                for participant in self.participants
             ],
-        }
-        self.history.append(turn_data)
+        })
 
     def to_json(self):
         return json.dumps({
             'track_profile': self.track_profile,
-            'segments': self.segments,
+            'segments': [{'type': segment.type, 'length': segment.length} for segment in self.segments],
             'turns': self.history,
         })

--- a/tests/test_race_engine.py
+++ b/tests/test_race_engine.py
@@ -1,0 +1,46 @@
+import json
+import unittest
+
+from race_engine import CourseManager
+
+
+class RaceEngineTests(unittest.TestCase):
+    def test_replay_contains_expected_frontend_fields(self):
+        manager = CourseManager(
+            participants=[
+                {'id': 1, 'name': 'Rillette', 'emoji': '🐷', 'vitesse': 18, 'endurance': 18, 'force': 15, 'agilite': 14, 'strategy_profile': {'phase_1': 40, 'phase_2': 55, 'phase_3': 90}},
+                {'id': 2, 'name': 'Boudin', 'emoji': '🐽', 'vitesse': 17, 'endurance': 20, 'force': 16, 'agilite': 15, 'strategy_profile': {'phase_1': 35, 'phase_2': 50, 'phase_3': 85}},
+            ],
+            segments=[{'type': 'PLAT', 'length': 100}, {'type': 'VIRAGE', 'length': 80}, {'type': 'DESCENTE', 'length': 120}],
+        )
+
+        history = manager.run()
+        replay = json.loads(manager.to_json())
+
+        self.assertTrue(history)
+        self.assertIn('track_profile', replay)
+        self.assertIn('turns', replay)
+        self.assertIn('segments', replay)
+        pig_turn = replay['turns'][0]['pigs'][0]
+        self.assertIn('distance', pig_turn)
+        self.assertIn('vitesse_actuelle', pig_turn)
+        self.assertIn('fatigue', pig_turn)
+        self.assertIn('visual_event', pig_turn)
+
+    def test_recent_race_penalty_slows_runner(self):
+        segments = [{'type': 'PLAT', 'length': 120}]
+        manager = CourseManager(
+            participants=[
+                {'id': 1, 'name': 'Frais', 'emoji': '🐷', 'vitesse': 20, 'endurance': 18, 'force': 15, 'agilite': 15, 'strategy_profile': {'phase_1': 60, 'phase_2': 60, 'phase_3': 60}, 'recent_race_penalty_multiplier': 1.0},
+                {'id': 2, 'name': 'Use', 'emoji': '🐽', 'vitesse': 20, 'endurance': 18, 'force': 15, 'agilite': 15, 'strategy_profile': {'phase_1': 60, 'phase_2': 60, 'phase_3': 60}, 'recent_race_penalty_multiplier': 0.9},
+            ],
+            segments=segments,
+        )
+
+        manager.simulate_turn()
+        fresh, tired = manager.participants
+        self.assertGreater(fresh.distance, tired.distance)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Replace the coarse, distance-only race model with a tactical, segment-aware engine that models topology (PLAT/MONTEE/DESCENTE/VIRAGE/BOUE), three user strategy phases, drafting, fatigue and incidents so results depend on planning as well as raw stats.
- Expose tuning knobs in a central place so designers can balance behavior without changing the engine code.

### Description
- Rewrote the race engine into typed `Segment` and `RaceParticipant` dataclasses and a `CourseManager` that simulates per-turn progression across track segments, resolving phase (`phase_1`/`phase_2`/`phase_3`) from progress and computing terrain-sensitive base speeds, stumble risk, drafting bonuses, leader headwind fatigue and fatigue-driven speed penalties (`race_engine.py`).
- Moved and added balance constants into `data.py` (strategy bands, attack fatigue growth, segment speed caps, drafting ranges/bonuses, stumble base chances, variance and recent-race penalty floor) so tuning is data-driven.
- Wired recent-race / freshness penalty into the simulation bootstrap in `helpers.py` by computing a `recent_race_penalty_multiplier` and passing it into participants so recently-run pigs carry a speed malus.
- Added a replay-friendly per-turn snapshot format including `track_profile`, `segments`, and `turns` where each pig entry has `distance`, `vitesse_actuelle`, `fatigue`, `strategy`, `phase`, `segment_type`, `visual_event`, etc., and added `tests/test_race_engine.py` with regressions for the replay contract and recent-race penalty behavior.

### Testing
- Compiled updated modules with `python -m py_compile race_engine.py helpers.py data.py services/race_service.py models.py tests/test_race_engine.py` which succeeded.
- Ran unit tests with `python -m unittest tests/test_race_engine.py` and both tests passed (`OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2645d7588323b416b907d6766eb1)