### PR TITLE
Add Groin Jack blackjack game (blueprint, UI, routes and tests)

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -7,6 +7,7 @@ from routes.abattoir import abattoir_bp
 from routes.admin import admin_bp
 from routes.api import api_bp
 from routes.bourse import bourse_bp
+from routes.blackjack import blackjack_bp
 
 all_blueprints = [
     auth_bp,
@@ -18,4 +19,5 @@ all_blueprints = [
     admin_bp,
     api_bp,
     bourse_bp,
+    blackjack_bp,
 ]

--- a/routes/blackjack.py
+++ b/routes/blackjack.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+
+from extensions import db
+from models import User
+from services.finance_service import credit_user_balance, debit_user_balance
+
+blackjack_bp = Blueprint('blackjack', __name__)
+
+SUITS = ['♠', '♥', '♦', '♣']
+RANKS = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K']
+RANK_VALUES = {
+    'A': [1, 11],
+    '2': 2,
+    '3': 3,
+    '4': 4,
+    '5': 5,
+    '6': 6,
+    '7': 7,
+    '8': 8,
+    '9': 9,
+    '10': 10,
+    'J': 10,
+    'Q': 10,
+    'K': 10,
+}
+JOKERS = [
+    {'rank': 'JOKER', 'suit': '🃏', 'value': 0, 'is_joker': True, 'label': 'Joker Rouge'},
+    {'rank': 'JOKER', 'suit': '🃏', 'value': 0, 'is_joker': True, 'label': 'Joker Noir'},
+]
+JOKER_EFFECTS = [
+    "Le croupier glisse dans la boue : tu pioches une carte bonus.",
+    "Le Joker grogne et sème la panique à la table.",
+    "Intervention divine porcine : une carte supplémentaire tombe du sabot.",
+    "Le Joker rote bruyamment. Rien ne se passe, mais l'ambiance est bonne.",
+]
+
+MIN_BET = 5
+MAX_BET = 500
+SESSION_KEY = 'blackjack_game'
+
+
+def build_deck() -> list[dict[str, Any]]:
+    deck = []
+    for suit in SUITS:
+        for rank in RANKS:
+            deck.append({
+                'rank': rank,
+                'suit': suit,
+                'value': RANK_VALUES[rank],
+                'is_joker': False,
+                'label': f'{rank}{suit}',
+            })
+    deck.extend(JOKERS)
+    random.shuffle(deck)
+    return deck
+
+
+def hand_value(hand: list[dict[str, Any]]) -> int:
+    total = 0
+    aces = 0
+    for card in hand:
+        if card.get('is_joker'):
+            continue
+        value = card['value']
+        if isinstance(value, list):
+            total += 11
+            aces += 1
+        else:
+            total += value
+    while total > 21 and aces > 0:
+        total -= 10
+        aces -= 1
+    return total
+
+
+def load_game_state() -> dict[str, Any] | None:
+    return session.get(SESSION_KEY)
+
+
+def save_game_state(state: dict[str, Any]) -> None:
+    session[SESSION_KEY] = state
+    session.modified = True
+
+
+def clear_game_state() -> None:
+    session.pop(SESSION_KEY, None)
+    session.modified = True
+
+
+def _resolve_user() -> User | None:
+    user_id = session.get('user_id')
+    return User.query.get(user_id) if user_id else None
+
+
+def _finish_game(game: dict[str, Any], user: User) -> dict[str, Any]:
+    dealer_hand = game['dealer_hand']
+    deck = game['deck']
+
+    while hand_value(dealer_hand) < 17 and deck:
+        drawn = deck.pop()
+        dealer_hand.append(drawn)
+        if drawn.get('is_joker') and len(dealer_hand) > 1:
+            removable_indexes = [i for i, card in enumerate(dealer_hand) if not card.get('is_joker')]
+            if removable_indexes:
+                dealer_hand.pop(random.choice(removable_indexes))
+                game['joker_msg'] = "Le Joker a fait défausser une carte au croupier."
+
+    player_total = hand_value(game['player_hand'])
+    dealer_total = hand_value(dealer_hand)
+
+    if player_total > 21:
+        result = 'bust'
+    elif dealer_total > 21:
+        result = 'dealer_bust'
+    elif player_total > dealer_total:
+        result = 'win'
+    elif player_total < dealer_total:
+        result = 'lose'
+    else:
+        result = 'push'
+
+    game['phase'] = 'finished'
+    game['dealer_reveal'] = True
+    game['result'] = result
+    game['player_total'] = player_total
+    game['dealer_total'] = dealer_total
+    game['deck'] = deck
+
+    bet = round(float(game['bet']), 2)
+    if result in ('win', 'dealer_bust'):
+        winnings = round(bet * 2, 2)
+        credit_user_balance(
+            user.id,
+            winnings,
+            reason_code='blackjack_win',
+            reason_label='Victoire Groin Jack',
+            details=f'Victoire au blackjack porcin ({bet:.0f} 🪙 misés).',
+            reference_type='user',
+            reference_id=user.id,
+        )
+        game['winnings'] = winnings
+        db.session.commit()
+    elif result == 'push':
+        credit_user_balance(
+            user.id,
+            bet,
+            reason_code='blackjack_push',
+            reason_label='Égalité Groin Jack',
+            details=f'Égalité au blackjack porcin ({bet:.0f} 🪙 remboursés).',
+            reference_type='user',
+            reference_id=user.id,
+        )
+        game['winnings'] = bet
+        db.session.commit()
+    else:
+        game['winnings'] = 0
+
+    return game
+
+
+@blackjack_bp.route('/blackjack')
+def blackjack():
+    user = _resolve_user()
+    if not user:
+        return redirect(url_for('auth.login'))
+    return render_template(
+        'blackjack.html',
+        user=user,
+        active_page='blackjack',
+        game=load_game_state(),
+        min_bet=MIN_BET,
+        max_bet=MAX_BET,
+    )
+
+
+@blackjack_bp.route('/blackjack/deal', methods=['POST'])
+def blackjack_deal():
+    user = _resolve_user()
+    if not user:
+        return redirect(url_for('auth.login'))
+
+    current_game = load_game_state()
+    if current_game and current_game.get('phase') == 'playing':
+        flash('Une partie est déjà en cours.', 'warning')
+        return redirect(url_for('blackjack.blackjack'))
+
+    bet = request.form.get('bet', type=float, default=0)
+    if bet < MIN_BET or bet > MAX_BET:
+        flash(f'La mise doit être comprise entre {MIN_BET} et {MAX_BET} 🪙.', 'error')
+        return redirect(url_for('blackjack.blackjack'))
+    if not user.can_afford(bet):
+        flash("Pas assez de BitGroins pour lancer une partie.", 'error')
+        return redirect(url_for('blackjack.blackjack'))
+
+    ok = debit_user_balance(
+        user.id,
+        bet,
+        reason_code='blackjack_bet',
+        reason_label='Mise Groin Jack',
+        details=f'Mise de {bet:.0f} 🪙 au blackjack porcin.',
+        reference_type='user',
+        reference_id=user.id,
+    )
+    if not ok:
+        flash("Impossible de débiter la mise.", 'error')
+        return redirect(url_for('blackjack.blackjack'))
+    db.session.commit()
+
+    deck = build_deck()
+    player_hand = [deck.pop(), deck.pop()]
+    dealer_hand = [deck.pop(), deck.pop()]
+    joker_msg = None
+
+    if any(card.get('is_joker') for card in player_hand) and deck:
+        player_hand.append(deck.pop())
+        joker_msg = random.choice(JOKER_EFFECTS)
+
+    game = {
+        'phase': 'playing',
+        'bet': round(bet, 2),
+        'deck': deck,
+        'player_hand': player_hand,
+        'dealer_hand': dealer_hand,
+        'dealer_reveal': False,
+        'joker_msg': joker_msg,
+        'result': None,
+        'winnings': None,
+        'player_total': hand_value(player_hand),
+        'dealer_total': hand_value(dealer_hand),
+    }
+
+    if game['player_total'] == 21 and len([card for card in player_hand if not card.get('is_joker')]) == 2:
+        if game['dealer_total'] == 21:
+            game['phase'] = 'finished'
+            game['dealer_reveal'] = True
+            game['result'] = 'push'
+            game['winnings'] = bet
+            credit_user_balance(
+                user.id,
+                bet,
+                reason_code='blackjack_push',
+                reason_label='Égalité Groin Jack',
+                details='Blackjack partagé avec le croupier.',
+                reference_type='user',
+                reference_id=user.id,
+            )
+        else:
+            winnings = round(bet * 2.5, 2)
+            game['phase'] = 'finished'
+            game['dealer_reveal'] = True
+            game['result'] = 'blackjack'
+            game['winnings'] = winnings
+            credit_user_balance(
+                user.id,
+                winnings,
+                reason_code='blackjack_win',
+                reason_label='Blackjack Groin Jack',
+                details=f'Blackjack naturel payé 3:2 ({bet:.0f} 🪙 misés).',
+                reference_type='user',
+                reference_id=user.id,
+            )
+        db.session.commit()
+
+    save_game_state(game)
+    return redirect(url_for('blackjack.blackjack'))
+
+
+@blackjack_bp.route('/blackjack/hit', methods=['POST'])
+def blackjack_hit():
+    user = _resolve_user()
+    if not user:
+        return redirect(url_for('auth.login'))
+
+    game = load_game_state()
+    if not game or game.get('phase') != 'playing' or not game.get('deck'):
+        return redirect(url_for('blackjack.blackjack'))
+
+    drawn = game['deck'].pop()
+    game['player_hand'].append(drawn)
+    if drawn.get('is_joker') and game['deck']:
+        game['player_hand'].append(game['deck'].pop())
+        game['joker_msg'] = random.choice(JOKER_EFFECTS)
+
+    game['player_total'] = hand_value(game['player_hand'])
+    if game['player_total'] > 21:
+        game['phase'] = 'finished'
+        game['dealer_reveal'] = True
+        game['result'] = 'bust'
+        game['winnings'] = 0
+    elif game['player_total'] == 21:
+        game = _finish_game(game, user)
+
+    save_game_state(game)
+    return redirect(url_for('blackjack.blackjack'))
+
+
+@blackjack_bp.route('/blackjack/stand', methods=['POST'])
+def blackjack_stand():
+    user = _resolve_user()
+    if not user:
+        return redirect(url_for('auth.login'))
+
+    game = load_game_state()
+    if not game or game.get('phase') != 'playing':
+        return redirect(url_for('blackjack.blackjack'))
+
+    game = _finish_game(game, user)
+    save_game_state(game)
+    return redirect(url_for('blackjack.blackjack'))
+
+
+@blackjack_bp.route('/blackjack/double', methods=['POST'])
+def blackjack_double():
+    user = _resolve_user()
+    if not user:
+        return redirect(url_for('auth.login'))
+
+    game = load_game_state()
+    if not game or game.get('phase') != 'playing' or len(game.get('player_hand', [])) != 2:
+        return redirect(url_for('blackjack.blackjack'))
+
+    extra_bet = round(float(game['bet']), 2)
+    if not user.can_afford(extra_bet):
+        flash("Pas assez de BitGroins pour doubler.", 'error')
+        return redirect(url_for('blackjack.blackjack'))
+
+    ok = debit_user_balance(
+        user.id,
+        extra_bet,
+        reason_code='blackjack_double',
+        reason_label='Double Groin Jack',
+        details=f'Doublement de mise au blackjack (+{extra_bet:.0f} 🪙).',
+        reference_type='user',
+        reference_id=user.id,
+    )
+    if not ok:
+        flash("Impossible de doubler la mise.", 'error')
+        return redirect(url_for('blackjack.blackjack'))
+    db.session.commit()
+
+    game['bet'] = round(game['bet'] + extra_bet, 2)
+    if game['deck']:
+        game['player_hand'].append(game['deck'].pop())
+    game['player_total'] = hand_value(game['player_hand'])
+    game = _finish_game(game, user)
+    save_game_state(game)
+    return redirect(url_for('blackjack.blackjack'))
+
+
+@blackjack_bp.route('/blackjack/new', methods=['POST'])
+def blackjack_new():
+    if 'user_id' not in session:
+        return redirect(url_for('auth.login'))
+    clear_game_state()
+    return redirect(url_for('blackjack.blackjack'))

--- a/templates/_site_header.html
+++ b/templates/_site_header.html
@@ -60,6 +60,7 @@
                 <a href="/history" class="{{ nav_base }} {{ nav_active if active_page == 'history' else nav_idle }}">📋 Historique</a>
                 <a href="/legendes-pop" class="{{ nav_base }} {{ nav_active if active_page == 'legendes_pop' else nav_idle }}">🌟 Pop Cult'</a>
                 <a href="/cimetiere" class="{{ nav_base }} {{ nav_active if active_page == 'cimetiere' else nav_idle }}">⚰️ Cimetière</a>
+                <a href="/blackjack" class="{{ nav_base }} {{ nav_active if active_page == 'blackjack' else nav_idle }}">🃏 Groin Jack</a>
             </nav>
             {% endif %}
         </div>

--- a/templates/blackjack.html
+++ b/templates/blackjack.html
@@ -1,0 +1,181 @@
+{% include '_site_header.html' %}
+
+{% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+    <div class="max-w-5xl mx-auto px-4 pt-4 space-y-3">
+      {% for category, message in messages %}
+        <div class="rounded-2xl border px-4 py-3 text-sm font-semibold {% if category == 'success' %}border-emerald-400/30 bg-emerald-400/10 text-emerald-100{% elif category == 'warning' %}border-amber-400/30 bg-amber-400/10 text-amber-100{% else %}border-red-400/30 bg-red-400/10 text-red-100{% endif %}">
+          {{ message }}
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+{% endwith %}
+
+{% macro render_card(card, hidden=false) -%}
+  <div class="relative flex h-32 w-24 items-center justify-center rounded-2xl border text-center shadow-lg {% if hidden %}border-white/10 bg-white/5 text-white/30{% elif card.is_joker %}border-fuchsia-400/40 bg-fuchsia-400/20 text-fuchsia-100{% elif card.suit in ['♥', '♦'] %}border-rose-300/40 bg-white text-rose-600{% else %}border-slate-300/40 bg-white text-slate-900{% endif %}">
+    {% if hidden %}
+      <div>
+        <div class="text-3xl">🐽</div>
+        <div class="mt-2 text-xs uppercase tracking-[0.2em]">Cachée</div>
+      </div>
+    {% elif card.is_joker %}
+      <div>
+        <div class="text-4xl">🃏</div>
+        <div class="mt-2 text-xs font-black uppercase">{{ card.label }}</div>
+      </div>
+    {% else %}
+      <div class="absolute left-2 top-2 text-sm font-black">{{ card.rank }}{{ card.suit }}</div>
+      <div class="text-4xl font-black">{{ card.suit }}</div>
+      <div class="absolute bottom-2 right-2 rotate-180 text-sm font-black">{{ card.rank }}{{ card.suit }}</div>
+    {% endif %}
+  </div>
+{%- endmacro %}
+
+<!doctype html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Derby des Groins — Groin Jack</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-[radial-gradient(circle_at_top,rgba(83,24,109,0.96),rgba(18,6,26,1)_60%)] text-white">
+  <main class="max-w-6xl mx-auto px-4 py-8 space-y-8">
+    <section class="grid gap-6 lg:grid-cols-[1.3fr_0.7fr]">
+      <div class="rounded-3xl border border-pink-200/10 bg-white/5 p-6 shadow-2xl shadow-fuchsia-950/30">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p class="text-sm uppercase tracking-[0.35em] text-pink-200/45">Salon privé</p>
+            <h2 class="mt-2 text-4xl font-black text-pink-100">🃏 Groin Jack</h2>
+            <p class="mt-3 max-w-2xl text-sm text-white/70">Le blackjack le plus porcin de l'internet. Sabot de 54 cartes, deux jokers chaotiques et une table prête à engloutir vos BitGroins.</p>
+          </div>
+          <div class="rounded-2xl border border-yellow-400/20 bg-yellow-400/10 px-5 py-4 text-right">
+            <div class="text-xs uppercase tracking-[0.25em] text-yellow-100/55">Magot</div>
+            <div class="mt-1 text-3xl font-black text-yellow-300">{{ '%.2f'|format(user.balance) }} 🪙</div>
+          </div>
+        </div>
+
+        {% if game and game.joker_msg %}
+          <div class="mt-6 rounded-2xl border border-fuchsia-400/30 bg-fuchsia-500/10 px-4 py-3 text-sm text-fuchsia-100">
+            <strong>Joker porcin :</strong> {{ game.joker_msg }}
+          </div>
+        {% endif %}
+
+        <div class="mt-8 grid gap-6 lg:grid-cols-2">
+          <section class="rounded-3xl border border-white/10 bg-black/15 p-5">
+            <div class="flex items-center justify-between gap-3">
+              <h3 class="text-lg font-black">Croupier</h3>
+              <span class="text-sm text-white/55">
+                {% if game and game.dealer_reveal %}
+                  Score : {{ game.dealer_total }}
+                {% else %}
+                  Carte cachée…
+                {% endif %}
+              </span>
+            </div>
+            <div class="mt-4 flex flex-wrap gap-3">
+              {% if game %}
+                {% for card in game.dealer_hand %}
+                  {{ render_card(card, hidden=(loop.index0 == 1 and not game.dealer_reveal)) }}
+                {% endfor %}
+              {% else %}
+                <p class="text-sm text-white/45">Le croupier attend que quelqu'un ose miser.</p>
+              {% endif %}
+            </div>
+          </section>
+
+          <section class="rounded-3xl border border-white/10 bg-black/15 p-5">
+            <div class="flex items-center justify-between gap-3">
+              <h3 class="text-lg font-black">Toi</h3>
+              <span class="text-sm text-white/55">{% if game %}Score : {{ game.player_total }}{% else %}Prêt à jouer{% endif %}</span>
+            </div>
+            <div class="mt-4 flex flex-wrap gap-3">
+              {% if game %}
+                {% for card in game.player_hand %}
+                  {{ render_card(card) }}
+                {% endfor %}
+              {% else %}
+                <p class="text-sm text-white/45">Choisis une mise pour recevoir tes cartes.</p>
+              {% endif %}
+            </div>
+          </section>
+        </div>
+
+        {% if game and game.phase == 'finished' %}
+          <section class="mt-6 rounded-3xl border border-pink-200/10 bg-pink-100/5 p-5">
+            <p class="text-xs uppercase tracking-[0.25em] text-pink-100/40">Résultat</p>
+            <div class="mt-2 text-2xl font-black">
+              {% if game.result == 'blackjack' %}
+                BLACKJACK NATUREL — payé x2.5
+              {% elif game.result == 'dealer_bust' %}
+                Le croupier explose à plus de 21
+              {% elif game.result == 'win' %}
+                Victoire nette
+              {% elif game.result == 'push' %}
+                Égalité, mise remboursée
+              {% elif game.result == 'bust' %}
+                Bust : tu dépasses 21
+              {% else %}
+                Défaite, le croupier rafle tout
+              {% endif %}
+            </div>
+            <p class="mt-2 text-sm text-white/70">Mise : {{ '%.0f'|format(game.bet) }} 🪙 · {% if game.winnings %}Retour : {{ '%.0f'|format(game.winnings) }} 🪙{% else %}Aucun gain{% endif %}</p>
+            <form method="post" action="{{ url_for('blackjack.blackjack_new') }}" class="mt-4">
+              <button class="rounded-2xl bg-gradient-to-r from-pink-500 to-orange-400 px-5 py-3 text-sm font-black text-white shadow-lg shadow-pink-950/30 transition hover:-translate-y-0.5">Nouvelle donne</button>
+            </form>
+          </section>
+        {% endif %}
+      </div>
+
+      <aside class="space-y-6">
+        {% if not game or game.phase == 'finished' %}
+          <section class="rounded-3xl border border-white/10 bg-white/5 p-6">
+            <h3 class="text-lg font-black">Nouvelle donne</h3>
+            <p class="mt-2 text-sm text-white/65">Mise minimum {{ min_bet }} 🪙 · maximum {{ max_bet }} 🪙.</p>
+            <form method="post" action="{{ url_for('blackjack.blackjack_deal') }}" class="mt-5 space-y-4">
+              <label class="block">
+                <span class="mb-2 block text-sm font-semibold text-white/80">Mise</span>
+                <input name="bet" type="number" min="{{ min_bet }}" max="{{ max_bet }}" step="1" value="{{ min_bet }}" class="w-full rounded-2xl border border-white/10 bg-black/20 px-4 py-3 text-white outline-none ring-0">
+              </label>
+              <div class="flex flex-wrap gap-2">
+                {% for value in [5, 10, 25, 50, 100, 200] %}
+                  {% if value <= user.balance %}
+                    <button type="button" onclick="this.form.bet.value={{ value }}" class="rounded-xl border border-pink-200/15 bg-pink-300/10 px-3 py-2 text-xs font-black text-pink-100">{{ value }} 🪙</button>
+                  {% endif %}
+                {% endfor %}
+                {% if user.balance >= min_bet %}
+                  <button type="button" onclick="this.form.bet.value={{ [user.balance|round(0, 'floor'), max_bet]|min }}" class="rounded-xl border border-yellow-300/20 bg-yellow-300/10 px-3 py-2 text-xs font-black text-yellow-100">Max</button>
+                {% endif %}
+              </div>
+              <button class="w-full rounded-2xl bg-gradient-to-r from-fuchsia-500 to-pink-500 px-5 py-3 text-sm font-black text-white shadow-lg shadow-fuchsia-950/30 transition hover:-translate-y-0.5">Distribuer les cartes</button>
+            </form>
+          </section>
+        {% else %}
+          <section class="rounded-3xl border border-white/10 bg-white/5 p-6">
+            <h3 class="text-lg font-black">Décision</h3>
+            <p class="mt-2 text-sm text-white/65">Mise en cours : {{ '%.0f'|format(game.bet) }} 🪙 · Sabot : {{ game.deck|length }} cartes restantes.</p>
+            <div class="mt-5 grid gap-3">
+              <form method="post" action="{{ url_for('blackjack.blackjack_hit') }}"><button class="w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-sm font-black text-white transition hover:bg-white/15">Tirer</button></form>
+              <form method="post" action="{{ url_for('blackjack.blackjack_stand') }}"><button class="w-full rounded-2xl border border-white/10 bg-white/10 px-4 py-3 text-sm font-black text-white transition hover:bg-white/15">Rester</button></form>
+              {% if game.player_hand|length == 2 and user.balance >= game.bet %}
+                <form method="post" action="{{ url_for('blackjack.blackjack_double') }}"><button class="w-full rounded-2xl border border-yellow-300/20 bg-yellow-300/10 px-4 py-3 text-sm font-black text-yellow-100 transition hover:bg-yellow-300/15">Doubler ({{ '%.0f'|format(game.bet) }} 🪙)</button></form>
+              {% endif %}
+            </div>
+          </section>
+        {% endif %}
+
+        <section class="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/70">
+          <h3 class="text-lg font-black text-white">Règles du Groin Jack</h3>
+          <ul class="mt-4 space-y-2 list-disc pl-5">
+            <li>Blackjack naturel : paiement x2.5.</li>
+            <li>Victoire standard : paiement x2.</li>
+            <li>Égalité : remboursement de la mise.</li>
+            <li>Double possible uniquement sur les 2 premières cartes.</li>
+            <li>Les jokers n'ont pas de valeur mais peuvent déclencher un effet bonus.</li>
+          </ul>
+        </section>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/tests/test_blackjack.py
+++ b/tests/test_blackjack.py
@@ -1,0 +1,33 @@
+import unittest
+
+from routes.blackjack import build_deck, hand_value
+
+
+class BlackjackTests(unittest.TestCase):
+    def test_build_deck_contains_54_cards_and_two_jokers(self):
+        deck = build_deck()
+
+        self.assertEqual(len(deck), 54)
+        self.assertEqual(sum(1 for card in deck if card['is_joker']), 2)
+
+    def test_hand_value_uses_soft_aces(self):
+        hand = [
+            {'rank': 'A', 'suit': '♠', 'value': [1, 11], 'is_joker': False},
+            {'rank': '9', 'suit': '♦', 'value': 9, 'is_joker': False},
+            {'rank': 'A', 'suit': '♥', 'value': [1, 11], 'is_joker': False},
+        ]
+
+        self.assertEqual(hand_value(hand), 21)
+
+    def test_hand_value_ignores_jokers(self):
+        hand = [
+            {'rank': 'JOKER', 'suit': '🃏', 'value': 0, 'is_joker': True},
+            {'rank': 'K', 'suit': '♣', 'value': 10, 'is_joker': False},
+            {'rank': 'Q', 'suit': '♠', 'value': 10, 'is_joker': False},
+        ]
+
+        self.assertEqual(hand_value(hand), 20)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide an in-app blackjack mini-game ("Groin Jack") to let users gamble BitGroins against a dealer with a themed UI and special joker mechanics. 
- Integrate the game into the existing site navigation and session flow so logged-in users can play and manage bets. 
- Include unit tests to validate core card/deck logic before shipping the feature.

### Description
- Adds a new Flask blueprint `routes/blackjack.py` implementing game logic, endpoints (`/blackjack`, `/blackjack/deal`, `/blackjack/hit`, `/blackjack/stand`, `/blackjack/double`, `/blackjack/new`), session state management (`SESSION_KEY='blackjack_game'`) and interactions with `credit_user_balance`/`debit_user_balance` for payouts and bets. 
- Implements a 54-card deck with two jokers and special joker effects, hand evaluation with soft aces via `hand_value`, and game resolution logic including blackjack, push, bust, dealer rules and payouts. 
- Adds a new template `templates/blackjack.html` for the game UI and updates `templates/_site_header.html` to expose a navigation link to `/blackjack`, and registers the blueprint in `routes/__init__.py`. 
- Adds unit tests in `tests/test_blackjack.py` covering `build_deck` and `hand_value` behaviors.

### Testing
- Ran the new unit tests in `tests/test_blackjack.py` which include `test_build_deck_contains_54_cards_and_two_jokers`, `test_hand_value_uses_soft_aces`, and `test_hand_value_ignores_jokers`, and all tests succeeded. 
- No other automated test suites were changed or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0f28c985c83239c67437c4e563965)