### PR TITLE
Améliore onglets Classement et Journal BitGroins (filtre & tri)

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -490,13 +490,31 @@ def history():
         target_user = current_user
     
     all_users = User.query.order_by(User.username).all()
-    
+
     bets = Bet.query.filter_by(user_id=target_user.id).order_by(Bet.placed_at.desc()).all()
-    transactions = BalanceTransaction.query.filter_by(user_id=target_user.id).order_by(BalanceTransaction.created_at.desc(), BalanceTransaction.id.desc()).all()
-    
-    global_transactions = []
+
+    tx_filter_raw = request.args.get('tx_u', 'all' if current_user.is_admin else str(current_user.id))
+    tx_filter_user = None
+
+    tx_query = BalanceTransaction.query.order_by(BalanceTransaction.created_at.desc(), BalanceTransaction.id.desc())
     if current_user.is_admin:
-        global_transactions = BalanceTransaction.query.order_by(BalanceTransaction.created_at.desc(), BalanceTransaction.id.desc()).all()
+        if tx_filter_raw != 'all':
+            try:
+                tx_filter_id = int(tx_filter_raw)
+            except (TypeError, ValueError):
+                tx_filter_id = current_user.id
+            tx_filter_user = User.query.get(tx_filter_id)
+            if tx_filter_user:
+                tx_query = tx_query.filter_by(user_id=tx_filter_user.id)
+            else:
+                tx_filter_raw = 'all'
+                tx_filter_user = None
+    else:
+        tx_filter_raw = str(current_user.id)
+        tx_filter_user = current_user
+        tx_query = tx_query.filter_by(user_id=current_user.id)
+
+    transactions = tx_query.all()
 
     race_history = get_race_history_entries()
 
@@ -516,7 +534,8 @@ def history():
         lost_bets=lost_bets,
         settled_bets=settled_bets,
         transactions=transactions,
-        global_transactions=global_transactions,
+        tx_filter_raw=tx_filter_raw,
+        tx_filter_user=tx_filter_user,
         race_history=race_history,
         bet_types=get_configured_bet_types(),
         credited_amount=credited_amount,

--- a/templates/classement.html
+++ b/templates/classement.html
@@ -109,11 +109,11 @@
 
     <!-- ===== ONGLETS ===== -->
     <div class="flex flex-wrap gap-2 mb-6">
-        <button class="tab-btn active card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer" data-tab="general">🏆 General</button>
-        <button class="tab-btn card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer text-white/50" data-tab="abattoir">🔪 Abattoir & Cimetiere</button>
-        <button class="tab-btn card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer text-white/50" data-tab="paris">🎟️ Paris & Fortune</button>
-        <button class="tab-btn card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer text-white/50" data-tab="elevage">🐷 Elevage & Ecole</button>
-        <button class="tab-btn card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer text-white/50" data-tab="honte">💩 Mur de la Honte</button>
+        <button type="button" class="tab-btn active card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer" data-tab="general">🏆 General</button>
+        <button type="button" class="tab-btn card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer text-white/50" data-tab="abattoir">🔪 Abattoir & Cimetiere</button>
+        <button type="button" class="tab-btn card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer text-white/50" data-tab="paris">🎟️ Paris & Fortune</button>
+        <button type="button" class="tab-btn card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer text-white/50" data-tab="elevage">🐷 Elevage & Ecole</button>
+        <button type="button" class="tab-btn card px-4 py-3 text-sm font-bold border border-white/10 cursor-pointer text-white/50" data-tab="honte">💩 Mur de la Honte</button>
     </div>
 
     <!-- ==================== TAB: GENERAL ==================== -->
@@ -604,15 +604,29 @@
 
 <script>
     // ===== TABS =====
-    document.querySelectorAll('.tab-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
-            document.querySelectorAll('.tab-btn').forEach(b => { b.classList.remove('active'); b.classList.add('text-white/50'); });
-            document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+    function activateClassementTab(tabName) {
+        const panel = document.getElementById('tab-' + tabName);
+        if (!panel) return;
+        document.querySelectorAll('.tab-btn').forEach(b => { b.classList.remove('active'); b.classList.add('text-white/50'); });
+        document.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+        const btn = document.querySelector('.tab-btn[data-tab="' + tabName + '"]');
+        if (btn) {
             btn.classList.add('active');
             btn.classList.remove('text-white/50');
-            document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+        }
+        panel.classList.add('active');
+        history.replaceState(null, '', '#tab=' + tabName);
+    }
+
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            e.preventDefault();
+            activateClassementTab(btn.dataset.tab);
         });
     });
+
+    const hashTab = (window.location.hash || '').replace('#tab=', '');
+    if (hashTab) activateClassementTab(hashTab);
 
     // ===== CHART DATA =====
     const chartLabels = {{ chart_data.labels | tojson }};

--- a/templates/history.html
+++ b/templates/history.html
@@ -65,6 +65,18 @@
             vertical-align: top;
         }
         .table-shell tr:last-child td { border-bottom: none; }
+        .tx-sort-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            font: inherit;
+            color: inherit;
+            background: transparent;
+            border: none;
+            cursor: pointer;
+            padding: 0;
+        }
+        .tx-sort-btn:hover { color: rgba(255, 255, 255, 0.9); }
     </style>
 </head>
 <body>
@@ -232,22 +244,45 @@
                 <h2 class="font-title text-3xl text-white">💰 Journal BitGroins</h2>
                 <p class="text-white/45 font-semibold mt-1">Chaque credit, debit, remboursement ou prime reste visible pour reconstituer ton solde.</p>
             </div>
-            
-            <form method="GET" action="/history" class="flex items-center gap-3">
-                <label for="u_filter" class="text-xs font-bold text-white/40 uppercase tracking-wider">Inspecter un eleveur :</label>
-                <select name="u" id="u_filter" onchange="this.form.submit()"
-                        class="bg-white/5 border border-white/10 rounded-xl px-4 py-2 text-white font-bold text-sm focus:outline-none focus:border-cyan-500/50">
-                    {% for u in all_users %}
-                    <option value="{{ u.id }}" {% if u.id == target_user.id %}selected{% endif %}>{{ u.username }}</option>
-                    {% endfor %}
-                </select>
+
+            <form method="GET" action="/history" class="flex flex-wrap items-center gap-3 rounded-2xl border border-cyan-400/15 bg-cyan-500/5 px-3 py-2">
+                <input type="hidden" name="u" value="{{ target_user.id }}">
+                <label for="tx_u_filter" class="text-xs font-bold text-cyan-100/70 uppercase tracking-wider">Filtre journal :</label>
+                <div class="relative">
+                    <select name="tx_u" id="tx_u_filter" onchange="this.form.submit()"
+                            class="appearance-none min-w-[220px] bg-white/5 border border-white/10 rounded-xl pl-4 pr-10 py-2 text-white font-bold text-sm focus:outline-none focus:border-cyan-500/60">
+                        {% if user.is_admin %}
+                        <option value="all" {% if tx_filter_raw == 'all' %}selected{% endif %}>👥 Tous les utilisateurs</option>
+                        {% endif %}
+                        {% for u in all_users %}
+                        <option value="{{ u.id }}" {% if tx_filter_raw == (u.id|string) %}selected{% endif %}>{{ u.username }}</option>
+                        {% endfor %}
+                    </select>
+                    <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-white/50">▾</span>
+                </div>
+                {% if user.is_admin and tx_filter_raw != 'all' %}
+                <a href="/history?u={{ target_user.id }}#bitgroins"
+                   class="inline-flex items-center gap-1 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-bold text-white/70 hover:bg-white/10 transition-colors">
+                    Réinitialiser
+                </a>
+                {% endif %}
             </form>
         </div>
 
         <div class="card p-5 lg:p-6 space-y-4">
             <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                    <h3 class="text-white text-xl font-extrabold">{% if target_user.id == user.id %}Mon journal{% else %}Journal de {{ target_user.username }}{% endif %} 🪙 BitGroins</h3>
+                    <h3 class="text-white text-xl font-extrabold">
+                        {% if user.is_admin and tx_filter_raw == 'all' %}
+                        Journal global des utilisateurs 🪙 BitGroins
+                        {% elif tx_filter_user %}
+                        Journal de {{ tx_filter_user.username }} 🪙 BitGroins
+                        {% elif target_user.id == user.id %}
+                        Mon journal 🪙 BitGroins
+                        {% else %}
+                        Journal de {{ target_user.username }} 🪙 BitGroins
+                        {% endif %}
+                    </h3>
                     <p class="text-white/45 text-sm font-semibold mt-1">Les mouvements sont horodates et incluent le solde apres transaction.</p>
                 </div>
                 <span class="pill bg-cyan-400/12 text-cyan-200 border border-cyan-400/20">{{ transactions | length }} mouvement(s)</span>
@@ -255,20 +290,26 @@
 
             {% if transactions %}
             <div class="table-shell overflow-x-auto">
-                <table>
+                <table id="bitgroins-table">
                     <thead>
                         <tr>
-                            <th>Date</th>
-                            <th>Mouvement</th>
+                            <th><button type="button" class="tx-sort-btn" data-sort-key="date">Date ↕</button></th>
+                            {% if user.is_admin %}
+                            <th><button type="button" class="tx-sort-btn" data-sort-key="user">Utilisateur ↕</button></th>
+                            {% endif %}
+                            <th><button type="button" class="tx-sort-btn" data-sort-key="amount">Mouvement ↕</button></th>
                             <th>Detail</th>
-                            <th>Solde apres</th>
+                            <th><button type="button" class="tx-sort-btn" data-sort-key="balance">Solde apres ↕</button></th>
                         </tr>
                     </thead>
-                    <tbody>
+                    <tbody id="bitgroins-table-body">
                         {% for tx in transactions %}
                         {% set amount_color = 'text-emerald-300' if tx.amount > 0 else ('text-rose-300' if tx.amount < 0 else 'text-cyan-200') %}
-                        <tr>
+                        <tr data-date="{{ tx.created_at.timestamp() }}" data-user="{{ (tx.user.username if tx.user else 'Utilisateur supprime')|lower }}" data-amount="{{ tx.amount }}" data-balance="{{ tx.balance_after or 0 }}">
                             <td class="text-white/70 text-sm font-bold whitespace-nowrap">{{ tx.created_at.strftime('%d/%m/%Y %H:%M') }}</td>
+                            {% if user.is_admin %}
+                            <td class="text-white font-bold whitespace-nowrap">{{ tx.user.username if tx.user else 'Utilisateur supprime' }}</td>
+                            {% endif %}
                             <td>
                                 <p class="font-extrabold {{ amount_color }}">
                                     {% if tx.amount > 0 %}+{% endif %}{{ "%.2f"|format(tx.amount) }} 🪙
@@ -297,62 +338,6 @@
             {% endif %}
         </div>
 
-        {% if user.is_admin %}
-        <div class="card p-5 lg:p-6 space-y-4">
-            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                    <h3 class="text-white text-xl font-extrabold">Vue admin - flux global des utilisateurs</h3>
-                    <p class="text-white/45 text-sm font-semibold mt-1">Pratique pour remonter un litige, une suspicion de triche ou une incoherence de solde.</p>
-                </div>
-                <span class="pill bg-indigo-400/12 text-indigo-200 border border-indigo-400/20">{{ global_transactions | length }} entree(s)</span>
-            </div>
-
-            {% if global_transactions %}
-            <div class="table-shell overflow-x-auto">
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Utilisateur</th>
-                            <th>Mouvement</th>
-                            <th>Detail</th>
-                            <th>Solde apres</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for tx in global_transactions %}
-                        {% set amount_color = 'text-emerald-300' if tx.amount > 0 else ('text-rose-300' if tx.amount < 0 else 'text-cyan-200') %}
-                        <tr>
-                            <td class="text-white/70 text-sm font-bold whitespace-nowrap">{{ tx.created_at.strftime('%d/%m/%Y %H:%M') }}</td>
-                            <td class="text-white font-bold">{{ tx.user.username if tx.user else 'Utilisateur supprime' }}</td>
-                            <td>
-                                <p class="font-extrabold {{ amount_color }}">
-                                    {% if tx.amount > 0 %}+{% endif %}{{ "%.2f"|format(tx.amount) }} 🪙
-                                </p>
-                                <p class="text-white/35 text-xs font-semibold mt-1">{{ tx.reason_label }}</p>
-                            </td>
-                            <td>
-                                <p class="text-white font-bold">{{ tx.details or 'Aucun detail complementaire' }}</p>
-                                <p class="text-white/35 text-xs font-semibold mt-1">
-                                    Avant {{ "%.2f"|format(tx.balance_before or 0) }} 🪙
-                                    {% if tx.reference_type and tx.reference_id %}
-                                    • {{ tx.reference_type }} #{{ tx.reference_id }}
-                                    {% endif %}
-                                </p>
-                            </td>
-                            <td class="text-white font-extrabold whitespace-nowrap">{{ "%.2f"|format(tx.balance_after or 0) }} 🪙</td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-            {% else %}
-            <div class="soft-card p-8 text-center">
-                <p class="text-white/50 font-bold">Aucun flux global enregistre.</p>
-            </div>
-            {% endif %}
-        </div>
-        {% endif %}
     </section>
 
     <section id="paris" class="space-y-4">
@@ -462,6 +447,40 @@
   // Activate from URL hash or default to courses
   const hash = window.location.hash.replace('#', '');
   activate(sections[hash] ? hash : 'courses');
+
+  const sortButtons = document.querySelectorAll('.tx-sort-btn');
+  const txBody = document.getElementById('bitgroins-table-body');
+  if (txBody && sortButtons.length) {
+    const state = { key: 'date', dir: 'desc' };
+    const parseVal = (row, key) => {
+      if (key === 'user') return (row.dataset.user || '').toLowerCase();
+      const n = Number(row.dataset[key] || 0);
+      return Number.isNaN(n) ? 0 : n;
+    };
+    const sortRows = (key, dir) => {
+      const rows = Array.from(txBody.querySelectorAll('tr'));
+      rows.sort((a, b) => {
+        const va = parseVal(a, key);
+        const vb = parseVal(b, key);
+        if (typeof va === 'string') {
+          const cmp = va.localeCompare(vb, 'fr');
+          return dir === 'asc' ? cmp : -cmp;
+        }
+        return dir === 'asc' ? va - vb : vb - va;
+      });
+      rows.forEach(r => txBody.appendChild(r));
+    };
+
+    sortButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const key = btn.dataset.sortKey;
+        const nextDir = (state.key === key && state.dir === 'asc') ? 'desc' : 'asc';
+        state.key = key;
+        state.dir = nextDir;
+        sortRows(key, nextDir);
+      });
+    });
+  }
 })();
 </script>
 {% include '_footer.html' %}


### PR DESCRIPTION
### Motivation

- Fiabiliser le comportement des onglets de la page `classement` pour éviter des activations intermittentes et permettre la persistance via le hash d'URL. 
- Rendre la vue « Journal BitGroins » plus utile pour les admins en affichant par défaut le flux global et en offrant un filtre moderne et lisible. 
- Ajouter un tri côté client et une colonne « Utilisateur » pour faciliter l'analyse des mouvements BitGroins.

### Description

- `routes/main.py` : ajout du paramètre de requête `tx_u` (valeur `all` pour les admins) et construction d'une seule requête `tx_query` pour récupérer les `BalanceTransaction` filtrées; on transmet `tx_filter_raw` et `tx_filter_user` au template. 
- `templates/history.html` : remplacement des deux tableaux admin/non-admin par un tableau unique filtrable; ajout d'un sélecteur stylé pour le filtre (`tx_u`) avec option « Tous les utilisateurs » et bouton de réinitialisation; en vue admin on affiche la colonne `Utilisateur`. 
- `templates/history.html` : le tableau contient désormais des `data-` (date, user, amount, balance), des boutons d'en-tête pour trier (`Date / Utilisateur / Mouvement / Solde`) et un script JS qui effectue le tri client-side. 
- `templates/classement.html` : onglets rendus robustes (`type="button"`), activation centralisée et conservation de l'onglet via hash `#tab=...` (utilise `history.replaceState`).

### Testing

- Compilation du module modifié : `python -m compileall routes/main.py` — succès. 
- Tests unitaires exécutés en environnement CI local : `PYTHONPATH=. pytest -q` — 6 tests verts, 3 échecs (tests existants liés aux routes de `bet`/`truffes` vérifiant des codes HTTP attendus), 408 warnings; les échecs semblent préexistants et non causés par ces changements. 
- Exécution de `pytest -q` sans `PYTHONPATH=.` dans cet environnement a échoué à la collecte (`ModuleNotFoundError`), ce comportement est lié à la configuration d'import du runner et non aux modifications apportées.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cda1e70e8083238cb879f775e8cbaa)