### PR TITLE
Add authentication event logging with purge service, CLI and scheduled job

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from models import (
 from data import PIG_ORIGINS, CEREALS, TRAININGS, SCHOOL_LESSONS
 from helpers import init_default_config, ensure_next_race, get_first_injured_pig
 from services.finance_service import record_balance_transaction
+from services.auth_log_service import purge_old_auth_events
 from services.pig_service import apply_origin_bonus, generate_weight_kg_for_profile, clamp_pig_weight, create_preloaded_admin_pigs, build_unique_pig_name
 from routes import all_blueprints
 from scheduler import start_scheduler, should_autostart_scheduler
@@ -74,6 +75,7 @@ def create_app():
     app.config['PIG_VITALS_COMMIT_INTERVAL_SECONDS'] = int(
         os.environ.get('PIG_VITALS_COMMIT_INTERVAL_SECONDS', '60')
     )
+    app.config['AUTH_LOG_RETENTION_DAYS'] = int(os.environ.get('AUTH_LOG_RETENTION_DAYS', '180'))
 
     db.init_app(app)
     migrate.init_app(app, db)
@@ -177,6 +179,14 @@ def register_cli_commands(app):
         """Peuple les données initiales de l'application."""
         run_seeders(with_admin=with_admin)
         click.echo('✅ Seed termine.')
+
+    @app.cli.command('purge-auth-logs')
+    @click.option('--days', default=None, type=int, help='Override retention days for this run.')
+    def purge_auth_logs_command(days):
+        """Supprime les événements d'authentification anciens."""
+        retention_days = int(days or app.config.get('AUTH_LOG_RETENTION_DAYS', 180))
+        deleted_count = purge_old_auth_events(retention_days)
+        click.echo(f'🧹 Auth logs purgés: {deleted_count} (rétention: {retention_days} jours)')
 
 
 def ensure_admin_user():

--- a/models.py
+++ b/models.py
@@ -964,6 +964,28 @@ class PigAvatar(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 
+class AuthEventLog(db.Model):
+    """Journal des événements de connexion/authentification."""
+    __tablename__ = 'auth_event_log'
+
+    id = db.Column(db.Integer, primary_key=True)
+    event_type = db.Column(db.String(40), nullable=False)
+    is_success = db.Column(db.Boolean, nullable=False, default=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True, index=True)
+    username_attempt = db.Column(db.String(80), nullable=True, index=True)
+    ip_address = db.Column(db.String(64), nullable=False, index=True)
+    user_agent = db.Column(db.String(300), nullable=True)
+    route = db.Column(db.String(120), nullable=True)
+    details = db.Column(db.String(255), nullable=True)
+    occurred_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, index=True)
+
+    user = db.relationship('User', backref=db.backref('auth_events', lazy=True))
+
+    __table_args__ = (
+        db.Index('ix_auth_event_type_time', 'event_type', 'occurred_at'),
+    )
+
+
 # ──────────────────────────────────────────────────────────
 # 🐷 GROIN POKER — modèles multijoueur
 # ──────────────────────────────────────────────────────────

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -12,6 +12,7 @@ from data import PIG_ORIGINS, RARITIES
 from helpers import get_config, get_market_unlock_progress, get_market_lock_reason
 from services.economy_service import get_configured_bet_types, get_welcome_bonus_value
 from services.finance_service import record_balance_transaction
+from services.auth_log_service import log_auth_event
 from services.pig_service import apply_origin_bonus, generate_weight_kg_for_profile, get_active_listing_count, build_unique_pig_name
 
 auth_bp = Blueprint('auth', __name__)
@@ -50,6 +51,12 @@ def register():
         apply_origin_bonus(pig, origin)
         pig.weight_kg = generate_weight_kg_for_profile(pig)
         db.session.add(pig)
+        log_auth_event(
+            event_type='register',
+            is_success=True,
+            user_id=user.id,
+            username_attempt=username,
+        )
         db.session.commit()
         session['user_id'] = user.id
         return redirect(url_for('pig.mon_cochon'))
@@ -64,7 +71,21 @@ def login():
         password = request.form.get('password', '').strip()
         user = User.query.filter_by(username=username).first()
         if not user or not check_password_hash(user.password_hash, password):
+            log_auth_event(
+                event_type='login',
+                is_success=False,
+                username_attempt=username,
+                details='invalid_credentials',
+            )
+            db.session.commit()
             return render_template('auth.html', error="Identifiants incorrects !", mode='login')
+        log_auth_event(
+            event_type='login',
+            is_success=True,
+            user_id=user.id,
+            username_attempt=username,
+        )
+        db.session.commit()
         session['user_id'] = user.id
         next_url = request.args.get('next') or request.form.get('next')
         if next_url:
@@ -91,6 +112,12 @@ def magic_login(token):
         # Found matching token — check expiry
         expires = datetime.fromisoformat(data['expires'])
         if datetime.utcnow() > expires:
+            log_auth_event(
+                event_type='magic_login',
+                is_success=False,
+                username_attempt=str(data.get('user_id', '')),
+                details='expired_token',
+            )
             db.session.delete(cfg)
             db.session.commit()
             flash("Ce lien magique a expire.", "error")
@@ -98,8 +125,21 @@ def magic_login(token):
         # Valid token — log in
         user = User.query.get(data['user_id'])
         if not user:
+            log_auth_event(
+                event_type='magic_login',
+                is_success=False,
+                username_attempt=str(data.get('user_id', '')),
+                details='user_not_found',
+            )
             flash("Utilisateur introuvable.", "error")
+            db.session.commit()
             return redirect(url_for('auth.login'))
+        log_auth_event(
+            event_type='magic_login',
+            is_success=True,
+            user_id=user.id,
+            username_attempt=user.username,
+        )
         session['user_id'] = user.id
         # Consume the token
         db.session.delete(cfg)
@@ -113,6 +153,14 @@ def magic_login(token):
 
 @auth_bp.route('/logout')
 def logout():
+    user_id = session.get('user_id')
+    if user_id:
+        log_auth_event(
+            event_type='logout',
+            is_success=True,
+            user_id=user_id,
+        )
+        db.session.commit()
     session.pop('user_id', None)
     return redirect(url_for('main.index'))
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -5,6 +5,7 @@ import os
 
 from extensions import db, APP_TIMEZONE
 from helpers import run_race_if_needed, ensure_next_race, resolve_auctions, check_vet_deadlines, resolve_market_history
+from services.auth_log_service import purge_old_auth_events
 
 scheduler = None
 
@@ -59,6 +60,18 @@ def start_scheduler(app):
         lambda: run_scheduler_job(app, 'market_history_tick', resolve_market_history),
         IntervalTrigger(minutes=10, timezone=APP_TIMEZONE),
         id='market-history-tick',
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    scheduler.add_job(
+        lambda: run_scheduler_job(
+            app,
+            'auth_log_purge',
+            lambda: purge_old_auth_events(app.config.get('AUTH_LOG_RETENTION_DAYS', 180)),
+        ),
+        IntervalTrigger(hours=24, timezone=APP_TIMEZONE),
+        id='auth-log-purge',
         replace_existing=True,
         max_instances=1,
         coalesce=True,

--- a/services/auth_log_service.py
+++ b/services/auth_log_service.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta
+
+from flask import request
+
+from extensions import db
+from models import AuthEventLog
+
+
+def _extract_client_ip() -> str:
+    forwarded_for = request.headers.get('X-Forwarded-For', '')
+    if forwarded_for:
+        first_ip = forwarded_for.split(',')[0].strip()
+        if first_ip:
+            return first_ip
+    return (request.headers.get('X-Real-IP') or request.remote_addr or '0.0.0.0').strip()
+
+
+def log_auth_event(
+    *,
+    event_type: str,
+    is_success: bool,
+    user_id: int | None = None,
+    username_attempt: str | None = None,
+    details: str | None = None,
+) -> None:
+    """Persiste un événement d'auth pour audit et sécurité."""
+    entry = AuthEventLog(
+        event_type=event_type,
+        is_success=bool(is_success),
+        user_id=user_id,
+        username_attempt=(username_attempt or None),
+        ip_address=_extract_client_ip(),
+        user_agent=(request.user_agent.string[:300] if request.user_agent else None),
+        route=request.path[:120] if request.path else None,
+        details=details[:255] if details else None,
+    )
+    db.session.add(entry)
+    db.session.flush()
+
+
+def purge_old_auth_events(retention_days: int) -> int:
+    """Supprime les logs auth plus anciens que la fenêtre de rétention."""
+    safe_days = max(1, int(retention_days or 1))
+    threshold = datetime.utcnow() - timedelta(days=safe_days)
+    deleted = AuthEventLog.query.filter(AuthEventLog.occurred_at < threshold).delete(synchronize_session=False)
+    db.session.commit()
+    return int(deleted or 0)

--- a/tests/test_auth_logs.py
+++ b/tests/test_auth_logs.py
@@ -1,0 +1,77 @@
+import unittest
+
+from app import create_app
+from extensions import db
+from models import AuthEventLog, User
+from services.auth_log_service import purge_old_auth_events
+
+
+class AuthLogsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = create_app()
+        cls.app.config['TESTING'] = True
+        cls.app.config['WTF_CSRF_ENABLED'] = False
+
+    def setUp(self):
+        self.client = self.app.test_client()
+
+    def test_failed_login_logs_ip_and_metadata(self):
+        response = self.client.post(
+            '/login',
+            data={'username': 'inconnu', 'password': 'bad-pass'},
+            headers={'X-Forwarded-For': '203.0.113.7'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        with self.app.app_context():
+            event = AuthEventLog.query.filter_by(event_type='login', is_success=False).order_by(AuthEventLog.id.desc()).first()
+            self.assertIsNotNone(event)
+            self.assertEqual(event.ip_address, '203.0.113.7')
+            self.assertEqual(event.username_attempt, 'inconnu')
+            self.assertEqual(event.route, '/login')
+
+    def test_logout_logs_event(self):
+        with self.app.app_context():
+            user = User.query.filter_by(username='auth-log-test-user').first()
+            if user is None:
+                user = User(username='auth-log-test-user', password_hash='x')
+                db.session.add(user)
+                db.session.commit()
+            user_id = int(user.id)
+
+        with self.client.session_transaction() as session:
+            session['user_id'] = user_id
+
+        response = self.client.get('/logout')
+        self.assertEqual(response.status_code, 302)
+
+        with self.app.app_context():
+            event = AuthEventLog.query.filter_by(event_type='logout', user_id=user_id).order_by(AuthEventLog.id.desc()).first()
+            self.assertIsNotNone(event)
+            self.assertTrue(event.is_success)
+
+    def test_purge_old_auth_logs_removes_expired_rows(self):
+        with self.app.app_context():
+            stale = AuthEventLog(
+                event_type='login',
+                is_success=False,
+                ip_address='198.51.100.10',
+                occurred_at=None,
+            )
+            db.session.add(stale)
+            db.session.flush()
+            stale_id = stale.id
+            stale.occurred_at = stale.occurred_at.replace(year=2000)
+            db.session.commit()
+
+            deleted = purge_old_auth_events(30)
+            self.assertGreaterEqual(deleted, 1)
+
+            still_there = AuthEventLog.query.get(stale_id)
+            self.assertIsNone(still_there)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide audit and security visibility for authentication actions (login/register/magic login/logout) and maintain a bounded retention window to limit stored sensitive data.

### Description

- Add `AuthEventLog` model (`auth_event_log` table) to store authentication events with metadata such as IP, user agent, route and timestamp.
- Implement `services/auth_log_service.py` with `log_auth_event` to record events and `purge_old_auth_events` to delete old rows based on retention days.
- Instrument authentication flows in `routes/auth.py` to call `log_auth_event` on register, login (success and failure), magic login (success/failure) and logout, and add `AUTH_LOG_RETENTION_DAYS` config in `app.py` with a new `purge-auth-logs` CLI command to run the purge manually.
- Schedule a daily purge job in `scheduler.py` that invokes `purge_old_auth_events` and add tests in `tests/test_auth_logs.py` covering logging and purge behavior.

### Testing

- Added unit tests in `tests/test_auth_logs.py` exercising failed login logging, logout logging, and `purge_old_auth_events`; these tests were run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdab10d4cc8323a593f4a24e65f5ff)