### PR TITLE
Add authentication event logging, admin viewer and retention purge

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,7 @@ from models import (
 from data import PIG_ORIGINS, CEREALS, TRAININGS, SCHOOL_LESSONS
 from helpers import init_default_config, ensure_next_race, get_first_injured_pig
 from services.finance_service import record_balance_transaction
+from services.auth_log_service import purge_old_auth_events
 from services.pig_service import apply_origin_bonus, generate_weight_kg_for_profile, clamp_pig_weight, create_preloaded_admin_pigs, build_unique_pig_name
 from routes import all_blueprints
 from scheduler import start_scheduler, should_autostart_scheduler
@@ -74,6 +75,7 @@ def create_app():
     app.config['PIG_VITALS_COMMIT_INTERVAL_SECONDS'] = int(
         os.environ.get('PIG_VITALS_COMMIT_INTERVAL_SECONDS', '60')
     )
+    app.config['AUTH_LOG_RETENTION_DAYS'] = int(os.environ.get('AUTH_LOG_RETENTION_DAYS', '180'))
 
     db.init_app(app)
     migrate.init_app(app, db)
@@ -177,6 +179,14 @@ def register_cli_commands(app):
         """Peuple les données initiales de l'application."""
         run_seeders(with_admin=with_admin)
         click.echo('✅ Seed termine.')
+
+    @app.cli.command('purge-auth-logs')
+    @click.option('--days', default=None, type=int, help='Override retention days for this run.')
+    def purge_auth_logs_command(days):
+        """Supprime les événements d'authentification anciens."""
+        retention_days = int(days or app.config.get('AUTH_LOG_RETENTION_DAYS', 180))
+        deleted_count = purge_old_auth_events(retention_days)
+        click.echo(f'🧹 Auth logs purgés: {deleted_count} (rétention: {retention_days} jours)')
 
 
 def ensure_admin_user():

--- a/models.py
+++ b/models.py
@@ -964,6 +964,28 @@ class PigAvatar(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
 
+class AuthEventLog(db.Model):
+    """Journal des événements de connexion/authentification."""
+    __tablename__ = 'auth_event_log'
+
+    id = db.Column(db.Integer, primary_key=True)
+    event_type = db.Column(db.String(40), nullable=False)
+    is_success = db.Column(db.Boolean, nullable=False, default=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True, index=True)
+    username_attempt = db.Column(db.String(80), nullable=True, index=True)
+    ip_address = db.Column(db.String(64), nullable=False, index=True)
+    user_agent = db.Column(db.String(300), nullable=True)
+    route = db.Column(db.String(120), nullable=True)
+    details = db.Column(db.String(255), nullable=True)
+    occurred_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow, index=True)
+
+    user = db.relationship('User', backref=db.backref('auth_events', lazy=True))
+
+    __table_args__ = (
+        db.Index('ix_auth_event_type_time', 'event_type', 'occurred_at'),
+    )
+
+
 # ──────────────────────────────────────────────────────────
 # 🐷 GROIN POKER — modèles multijoueur
 # ──────────────────────────────────────────────────────────

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -10,7 +10,7 @@ import re
 import secrets
 
 from extensions import db
-from models import User, Race, Pig, Bet, CerealItem, TrainingItem, SchoolLessonItem, PigAvatar
+from models import User, Race, Pig, Bet, CerealItem, TrainingItem, SchoolLessonItem, PigAvatar, AuthEventLog
 from data import JOURS_FR
 from helpers import (
     set_config, get_config, populate_race_participants, run_race_if_needed,
@@ -158,6 +158,50 @@ def admin_dashboard(user):
 
     return render_template('admin_dashboard.html',
         user=user, admin_tab='dashboard', stats=stats, recent_races=recent_races)
+
+
+@admin_bp.route('/admin/auth-logs')
+@admin_required
+def admin_auth_logs(user):
+    page = max(1, request.args.get('page', default=1, type=int) or 1)
+    event_type = (request.args.get('event_type', '') or '').strip()
+    success_filter = (request.args.get('success', '') or '').strip()
+    username = (request.args.get('username', '') or '').strip()
+    ip_address = (request.args.get('ip', '') or '').strip()
+
+    query = AuthEventLog.query
+    if event_type:
+        query = query.filter(AuthEventLog.event_type == event_type)
+    if success_filter == '1':
+        query = query.filter(AuthEventLog.is_success.is_(True))
+    elif success_filter == '0':
+        query = query.filter(AuthEventLog.is_success.is_(False))
+    if username:
+        query = query.filter(AuthEventLog.username_attempt.ilike(f"%{username}%"))
+    if ip_address:
+        query = query.filter(AuthEventLog.ip_address.ilike(f"%{ip_address}%"))
+
+    pagination = query.order_by(AuthEventLog.occurred_at.desc(), AuthEventLog.id.desc()).paginate(
+        page=page,
+        per_page=100,
+        error_out=False,
+    )
+    event_types = [row[0] for row in db.session.query(AuthEventLog.event_type).distinct().order_by(AuthEventLog.event_type).all()]
+
+    return render_template(
+        'admin_auth_logs.html',
+        user=user,
+        admin_tab='auth_logs',
+        pagination=pagination,
+        auth_logs=pagination.items,
+        filters={
+            'event_type': event_type,
+            'success': success_filter,
+            'username': username,
+            'ip': ip_address,
+        },
+        event_types=event_types,
+    )
 
 
 @admin_bp.route('/admin/economy', methods=['GET', 'POST'])

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -12,6 +12,7 @@ from data import PIG_ORIGINS, RARITIES
 from helpers import get_config, get_market_unlock_progress, get_market_lock_reason
 from services.economy_service import get_configured_bet_types, get_welcome_bonus_value
 from services.finance_service import record_balance_transaction
+from services.auth_log_service import log_auth_event
 from services.pig_service import apply_origin_bonus, generate_weight_kg_for_profile, get_active_listing_count, build_unique_pig_name
 
 auth_bp = Blueprint('auth', __name__)
@@ -50,6 +51,12 @@ def register():
         apply_origin_bonus(pig, origin)
         pig.weight_kg = generate_weight_kg_for_profile(pig)
         db.session.add(pig)
+        log_auth_event(
+            event_type='register',
+            is_success=True,
+            user_id=user.id,
+            username_attempt=username,
+        )
         db.session.commit()
         session['user_id'] = user.id
         return redirect(url_for('pig.mon_cochon'))
@@ -64,7 +71,21 @@ def login():
         password = request.form.get('password', '').strip()
         user = User.query.filter_by(username=username).first()
         if not user or not check_password_hash(user.password_hash, password):
+            log_auth_event(
+                event_type='login',
+                is_success=False,
+                username_attempt=username,
+                details='invalid_credentials',
+            )
+            db.session.commit()
             return render_template('auth.html', error="Identifiants incorrects !", mode='login')
+        log_auth_event(
+            event_type='login',
+            is_success=True,
+            user_id=user.id,
+            username_attempt=username,
+        )
+        db.session.commit()
         session['user_id'] = user.id
         next_url = request.args.get('next') or request.form.get('next')
         if next_url:
@@ -91,6 +112,12 @@ def magic_login(token):
         # Found matching token — check expiry
         expires = datetime.fromisoformat(data['expires'])
         if datetime.utcnow() > expires:
+            log_auth_event(
+                event_type='magic_login',
+                is_success=False,
+                username_attempt=str(data.get('user_id', '')),
+                details='expired_token',
+            )
             db.session.delete(cfg)
             db.session.commit()
             flash("Ce lien magique a expire.", "error")
@@ -98,8 +125,21 @@ def magic_login(token):
         # Valid token — log in
         user = User.query.get(data['user_id'])
         if not user:
+            log_auth_event(
+                event_type='magic_login',
+                is_success=False,
+                username_attempt=str(data.get('user_id', '')),
+                details='user_not_found',
+            )
             flash("Utilisateur introuvable.", "error")
+            db.session.commit()
             return redirect(url_for('auth.login'))
+        log_auth_event(
+            event_type='magic_login',
+            is_success=True,
+            user_id=user.id,
+            username_attempt=user.username,
+        )
         session['user_id'] = user.id
         # Consume the token
         db.session.delete(cfg)
@@ -113,6 +153,14 @@ def magic_login(token):
 
 @auth_bp.route('/logout')
 def logout():
+    user_id = session.get('user_id')
+    if user_id:
+        log_auth_event(
+            event_type='logout',
+            is_success=True,
+            user_id=user_id,
+        )
+        db.session.commit()
     session.pop('user_id', None)
     return redirect(url_for('main.index'))
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -5,6 +5,7 @@ import os
 
 from extensions import db, APP_TIMEZONE
 from helpers import run_race_if_needed, ensure_next_race, resolve_auctions, check_vet_deadlines, resolve_market_history
+from services.auth_log_service import purge_old_auth_events
 
 scheduler = None
 
@@ -59,6 +60,18 @@ def start_scheduler(app):
         lambda: run_scheduler_job(app, 'market_history_tick', resolve_market_history),
         IntervalTrigger(minutes=10, timezone=APP_TIMEZONE),
         id='market-history-tick',
+        replace_existing=True,
+        max_instances=1,
+        coalesce=True,
+    )
+    scheduler.add_job(
+        lambda: run_scheduler_job(
+            app,
+            'auth_log_purge',
+            lambda: purge_old_auth_events(app.config.get('AUTH_LOG_RETENTION_DAYS', 180)),
+        ),
+        IntervalTrigger(hours=24, timezone=APP_TIMEZONE),
+        id='auth-log-purge',
         replace_existing=True,
         max_instances=1,
         coalesce=True,

--- a/services/auth_log_service.py
+++ b/services/auth_log_service.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta
+
+from flask import request
+
+from extensions import db
+from models import AuthEventLog
+
+
+def _extract_client_ip() -> str:
+    forwarded_for = request.headers.get('X-Forwarded-For', '')
+    if forwarded_for:
+        first_ip = forwarded_for.split(',')[0].strip()
+        if first_ip:
+            return first_ip
+    return (request.headers.get('X-Real-IP') or request.remote_addr or '0.0.0.0').strip()
+
+
+def log_auth_event(
+    *,
+    event_type: str,
+    is_success: bool,
+    user_id: int | None = None,
+    username_attempt: str | None = None,
+    details: str | None = None,
+) -> None:
+    """Persiste un événement d'auth pour audit et sécurité."""
+    entry = AuthEventLog(
+        event_type=event_type,
+        is_success=bool(is_success),
+        user_id=user_id,
+        username_attempt=(username_attempt or None),
+        ip_address=_extract_client_ip(),
+        user_agent=(request.user_agent.string[:300] if request.user_agent else None),
+        route=request.path[:120] if request.path else None,
+        details=details[:255] if details else None,
+    )
+    db.session.add(entry)
+    db.session.flush()
+
+
+def purge_old_auth_events(retention_days: int) -> int:
+    """Supprime les logs auth plus anciens que la fenêtre de rétention."""
+    safe_days = max(1, int(retention_days or 1))
+    threshold = datetime.utcnow() - timedelta(days=safe_days)
+    deleted = AuthEventLog.query.filter(AuthEventLog.occurred_at < threshold).delete(synchronize_session=False)
+    db.session.commit()
+    return int(deleted or 0)

--- a/templates/admin_auth_logs.html
+++ b/templates/admin_auth_logs.html
@@ -1,0 +1,102 @@
+{% extends "admin_base.html" %}
+{% block title %}🔐 Journal des connexions{% endblock %}
+
+{% block content %}
+<div class="space-y-6">
+    <section class="glass-card p-5 md:p-6">
+        <div class="flex flex-wrap items-center justify-between gap-3 mb-4">
+            <h1 class="font-title text-2xl text-white">🔐 Journal des connexions</h1>
+            <div class="text-xs text-white/60">Affichage: {{ auth_logs|length }} / page (max 100)</div>
+        </div>
+
+        <form method="GET" class="grid grid-cols-1 md:grid-cols-5 gap-3">
+            <div>
+                <label class="text-xs text-white/60 block mb-1">Type</label>
+                <select name="event_type" class="w-full rounded-lg bg-white/5 border border-white/10 px-3 py-2 text-sm">
+                    <option value="">Tous</option>
+                    {% for t in event_types %}
+                        <option value="{{ t }}" {{ 'selected' if filters.event_type == t else '' }}>{{ t }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div>
+                <label class="text-xs text-white/60 block mb-1">Resultat</label>
+                <select name="success" class="w-full rounded-lg bg-white/5 border border-white/10 px-3 py-2 text-sm">
+                    <option value="" {{ 'selected' if not filters.success else '' }}>Tous</option>
+                    <option value="1" {{ 'selected' if filters.success == '1' else '' }}>Succes</option>
+                    <option value="0" {{ 'selected' if filters.success == '0' else '' }}>Echec</option>
+                </select>
+            </div>
+            <div>
+                <label class="text-xs text-white/60 block mb-1">Utilisateur</label>
+                <input type="text" name="username" value="{{ filters.username }}" placeholder="username tente" class="w-full rounded-lg bg-white/5 border border-white/10 px-3 py-2 text-sm">
+            </div>
+            <div>
+                <label class="text-xs text-white/60 block mb-1">IP</label>
+                <input type="text" name="ip" value="{{ filters.ip }}" placeholder="203.0.113" class="w-full rounded-lg bg-white/5 border border-white/10 px-3 py-2 text-sm">
+            </div>
+            <div class="flex items-end gap-2">
+                <button type="submit" class="btn-admin">Filtrer</button>
+                <a href="{{ url_for('admin.admin_auth_logs') }}" class="btn-admin" style="background: rgba(255,255,255,0.06);">Reset</a>
+            </div>
+        </form>
+    </section>
+
+    <section class="glass-card overflow-hidden">
+        <div class="overflow-x-auto">
+            <table class="w-full min-w-[980px] text-sm">
+                <thead class="bg-white/5 text-white/70">
+                    <tr>
+                        <th class="text-left px-3 py-2">Horodatage (UTC)</th>
+                        <th class="text-left px-3 py-2">Type</th>
+                        <th class="text-left px-3 py-2">Resultat</th>
+                        <th class="text-left px-3 py-2">User ID</th>
+                        <th class="text-left px-3 py-2">Username</th>
+                        <th class="text-left px-3 py-2">IP</th>
+                        <th class="text-left px-3 py-2">Route</th>
+                        <th class="text-left px-3 py-2">Details</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in auth_logs %}
+                    <tr class="border-t border-white/10">
+                        <td class="px-3 py-2 text-white/80">{{ row.occurred_at.strftime('%Y-%m-%d %H:%M:%S') if row.occurred_at else '-' }}</td>
+                        <td class="px-3 py-2 text-white">{{ row.event_type }}</td>
+                        <td class="px-3 py-2">
+                            {% if row.is_success %}
+                                <span class="text-green-400 font-bold">✅ succes</span>
+                            {% else %}
+                                <span class="text-red-400 font-bold">❌ echec</span>
+                            {% endif %}
+                        </td>
+                        <td class="px-3 py-2 text-white/80">{{ row.user_id or '-' }}</td>
+                        <td class="px-3 py-2 text-white/80">{{ row.username_attempt or '-' }}</td>
+                        <td class="px-3 py-2 text-white/80">{{ row.ip_address }}</td>
+                        <td class="px-3 py-2 text-white/70">{{ row.route or '-' }}</td>
+                        <td class="px-3 py-2 text-white/60">{{ row.details or '-' }}</td>
+                    </tr>
+                    {% else %}
+                    <tr>
+                        <td colspan="8" class="px-3 py-5 text-center text-white/50">Aucune entree pour ces filtres.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if pagination.pages > 1 %}
+        <div class="p-4 border-t border-white/10 flex items-center justify-between text-xs">
+            <div class="text-white/60">Page {{ pagination.page }} / {{ pagination.pages }}</div>
+            <div class="flex items-center gap-2">
+                {% if pagination.has_prev %}
+                    <a class="btn-admin text-xs" href="{{ url_for('admin.admin_auth_logs', page=pagination.prev_num, event_type=filters.event_type, success=filters.success, username=filters.username, ip=filters.ip) }}">← Prec</a>
+                {% endif %}
+                {% if pagination.has_next %}
+                    <a class="btn-admin text-xs" href="{{ url_for('admin.admin_auth_logs', page=pagination.next_num, event_type=filters.event_type, success=filters.success, username=filters.username, ip=filters.ip) }}">Suiv →</a>
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
+    </section>
+</div>
+{% endblock %}

--- a/templates/admin_base.html
+++ b/templates/admin_base.html
@@ -186,6 +186,9 @@
                 </a>
 
                 <div class="sidebar-section">Systeme</div>
+                <a href="{{ url_for('admin.admin_auth_logs') }}" class="sidebar-link {{ 'active' if admin_tab == 'auth_logs' }}">
+                    <span class="text-base w-6 text-center">🔐</span> Logs connexions
+                </a>
                 <a href="{{ url_for('admin.admin_notifications') }}" class="sidebar-link {{ 'active' if admin_tab == 'notifications' }}">
                     <span class="text-base w-6 text-center">📧</span> Notifications
                 </a>
@@ -226,6 +229,9 @@
             </a>
             <a href="{{ url_for('admin.admin_notifications') }}" class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg text-[10px] font-bold {{ 'text-indigo-400' if admin_tab == 'notifications' else 'text-white/40' }}">
                 <span class="text-lg">📧</span>SMTP
+            </a>
+            <a href="{{ url_for('admin.admin_auth_logs') }}" class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg text-[10px] font-bold {{ 'text-indigo-400' if admin_tab == 'auth_logs' else 'text-white/40' }}">
+                <span class="text-lg">🔐</span>Logs
             </a>
             <a href="{{ url_for('admin.admin_avatars') }}" class="flex flex-col items-center gap-0.5 px-2 py-1 rounded-lg text-[10px] font-bold {{ 'text-indigo-400' if admin_tab == 'avatars' else 'text-white/40' }}">
                 <span class="text-lg">🖼️</span>Avatars

--- a/tests/test_admin_auth_logs.py
+++ b/tests/test_admin_auth_logs.py
@@ -1,0 +1,42 @@
+import unittest
+
+from app import create_app
+from extensions import db
+from models import AuthEventLog, User
+
+
+class AdminAuthLogsRouteTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = create_app()
+        cls.app.config['TESTING'] = True
+        cls.app.config['WTF_CSRF_ENABLED'] = False
+
+    def setUp(self):
+        self.client = self.app.test_client()
+
+    def test_admin_auth_logs_requires_admin(self):
+        response = self.client.get('/admin/auth-logs')
+        self.assertEqual(response.status_code, 302)
+
+    def test_admin_auth_logs_page_is_accessible_for_admin(self):
+        with self.app.app_context():
+            admin = User.query.filter_by(username='auth-log-admin').first()
+            if admin is None:
+                admin = User(username='auth-log-admin', password_hash='x', is_admin=True)
+                db.session.add(admin)
+                db.session.flush()
+                db.session.add(AuthEventLog(event_type='login', is_success=True, user_id=admin.id, ip_address='127.0.0.1'))
+                db.session.commit()
+            admin_id = admin.id
+
+        with self.client.session_transaction() as session:
+            session['user_id'] = admin_id
+
+        response = self.client.get('/admin/auth-logs')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Journal des connexions', response.get_data(as_text=True))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_auth_logs.py
+++ b/tests/test_auth_logs.py
@@ -1,0 +1,77 @@
+import unittest
+
+from app import create_app
+from extensions import db
+from models import AuthEventLog, User
+from services.auth_log_service import purge_old_auth_events
+
+
+class AuthLogsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = create_app()
+        cls.app.config['TESTING'] = True
+        cls.app.config['WTF_CSRF_ENABLED'] = False
+
+    def setUp(self):
+        self.client = self.app.test_client()
+
+    def test_failed_login_logs_ip_and_metadata(self):
+        response = self.client.post(
+            '/login',
+            data={'username': 'inconnu', 'password': 'bad-pass'},
+            headers={'X-Forwarded-For': '203.0.113.7'},
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        with self.app.app_context():
+            event = AuthEventLog.query.filter_by(event_type='login', is_success=False).order_by(AuthEventLog.id.desc()).first()
+            self.assertIsNotNone(event)
+            self.assertEqual(event.ip_address, '203.0.113.7')
+            self.assertEqual(event.username_attempt, 'inconnu')
+            self.assertEqual(event.route, '/login')
+
+    def test_logout_logs_event(self):
+        with self.app.app_context():
+            user = User.query.filter_by(username='auth-log-test-user').first()
+            if user is None:
+                user = User(username='auth-log-test-user', password_hash='x')
+                db.session.add(user)
+                db.session.commit()
+            user_id = int(user.id)
+
+        with self.client.session_transaction() as session:
+            session['user_id'] = user_id
+
+        response = self.client.get('/logout')
+        self.assertEqual(response.status_code, 302)
+
+        with self.app.app_context():
+            event = AuthEventLog.query.filter_by(event_type='logout', user_id=user_id).order_by(AuthEventLog.id.desc()).first()
+            self.assertIsNotNone(event)
+            self.assertTrue(event.is_success)
+
+    def test_purge_old_auth_logs_removes_expired_rows(self):
+        with self.app.app_context():
+            stale = AuthEventLog(
+                event_type='login',
+                is_success=False,
+                ip_address='198.51.100.10',
+                occurred_at=None,
+            )
+            db.session.add(stale)
+            db.session.flush()
+            stale_id = stale.id
+            stale.occurred_at = stale.occurred_at.replace(year=2000)
+            db.session.commit()
+
+            deleted = purge_old_auth_events(30)
+            self.assertGreaterEqual(deleted, 1)
+
+            still_there = AuthEventLog.query.get(stale_id)
+            self.assertIsNone(still_there)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide an auditable record of authentication events (login/register/magic logout) for security and incident investigation. 
- Automatically remove old auth logs to limit storage and comply with retention policy.

### Description
- Add `AuthEventLog` model to `models.py` to store auth event metadata (`event_type`, `is_success`, `user_id`, `username_attempt`, `ip_address`, `user_agent`, `route`, `details`, `occurred_at`).
- Implement `services/auth_log_service.py` with `log_auth_event` to record events and `purge_old_auth_events` to delete entries older than a retention window, and wire the service into `routes/auth.py` (calls on register/login/magic login/logout).
- Add an admin UI and route to browse logs (`routes/admin.py` + `templates/admin_auth_logs.html`) and update `templates/admin_base.html` to expose the new section, plus a CLI command `purge-auth-logs` and `AUTH_LOG_RETENTION_DAYS` config in `app.py` to control retention.
- Schedule a daily purge job in `scheduler.py` to run `purge_old_auth_events` automatically and add tests covering logging, purge and the admin page (`tests/test_auth_logs.py`, `tests/test_admin_auth_logs.py`).

### Testing
- Ran unit tests `tests/test_auth_logs.py` which verify failed login and logout events are logged and that `purge_old_auth_events` removes expired rows, and they passed.
- Ran `tests/test_admin_auth_logs.py` which verifies admin access to `/admin/auth-logs` and the page rendering, and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cdab10d4cc8323a593f4a24e65f5ff)