### PR TITLE
Enable BitGroins history multi-user filter for all users

### DIFF
--- a/routes/main.py
+++ b/routes/main.py
@@ -493,26 +493,33 @@ def history():
 
     bets = Bet.query.filter_by(user_id=target_user.id).order_by(Bet.placed_at.desc()).all()
 
-    tx_filter_raw = request.args.get('tx_u', 'all' if current_user.is_admin else str(current_user.id))
+    tx_filter_values = request.args.getlist('tx_u')
+    tx_filter_raw = 'all'
     tx_filter_user = None
+    tx_filter_users = []
+    tx_selected_user_ids = []
 
     tx_query = BalanceTransaction.query.order_by(BalanceTransaction.created_at.desc(), BalanceTransaction.id.desc())
-    if current_user.is_admin:
-        if tx_filter_raw != 'all':
-            try:
-                tx_filter_id = int(tx_filter_raw)
-            except (TypeError, ValueError):
-                tx_filter_id = current_user.id
-            tx_filter_user = User.query.get(tx_filter_id)
-            if tx_filter_user:
-                tx_query = tx_query.filter_by(user_id=tx_filter_user.id)
-            else:
-                tx_filter_raw = 'all'
-                tx_filter_user = None
-    else:
-        tx_filter_raw = str(current_user.id)
-        tx_filter_user = current_user
-        tx_query = tx_query.filter_by(user_id=current_user.id)
+    selected_ids = []
+    for raw_value in tx_filter_values:
+        if raw_value == 'all':
+            selected_ids = []
+            break
+        try:
+            selected_ids.append(int(raw_value))
+        except (TypeError, ValueError):
+            continue
+
+    tx_selected_user_ids = sorted(set(selected_ids))
+    if tx_selected_user_ids:
+        tx_filter_users = User.query.filter(User.id.in_(tx_selected_user_ids)).order_by(User.username).all()
+        tx_selected_user_ids = [u.id for u in tx_filter_users]
+        if tx_selected_user_ids:
+            tx_query = tx_query.filter(BalanceTransaction.user_id.in_(tx_selected_user_ids))
+            tx_filter_raw = 'multi'
+            tx_filter_user = tx_filter_users[0] if len(tx_filter_users) == 1 else None
+        else:
+            tx_filter_raw = 'all'
 
     transactions = tx_query.all()
 
@@ -536,6 +543,8 @@ def history():
         transactions=transactions,
         tx_filter_raw=tx_filter_raw,
         tx_filter_user=tx_filter_user,
+        tx_filter_users=tx_filter_users,
+        tx_selected_user_ids=tx_selected_user_ids,
         race_history=race_history,
         bet_types=get_configured_bet_types(),
         credited_amount=credited_amount,

--- a/templates/history.html
+++ b/templates/history.html
@@ -247,20 +247,38 @@
 
             <form method="GET" action="/history" class="flex flex-wrap items-center gap-3 rounded-2xl border border-cyan-400/15 bg-cyan-500/5 px-3 py-2">
                 <input type="hidden" name="u" value="{{ target_user.id }}">
-                <label for="tx_u_filter" class="text-xs font-bold text-cyan-100/70 uppercase tracking-wider">Filtre journal :</label>
-                <div class="relative">
-                    <select name="tx_u" id="tx_u_filter" onchange="this.form.submit()"
-                            class="appearance-none min-w-[220px] bg-white/5 border border-white/10 rounded-xl pl-4 pr-10 py-2 text-white font-bold text-sm focus:outline-none focus:border-cyan-500/60">
-                        {% if user.is_admin %}
-                        <option value="all" {% if tx_filter_raw == 'all' %}selected{% endif %}>👥 Tous les utilisateurs</option>
-                        {% endif %}
+                <label class="text-xs font-bold text-cyan-100/70 uppercase tracking-wider">Filtre journal :</label>
+                <details class="relative group min-w-[260px]">
+                    <summary class="list-none cursor-pointer rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-bold text-white flex items-center justify-between gap-3">
+                        <span>
+                            {% if tx_filter_raw == 'all' %}
+                            👥 Tous les utilisateurs
+                            {% else %}
+                            👤 {{ tx_filter_users | map(attribute='username') | join(', ') }}
+                            {% endif %}
+                        </span>
+                        <span class="text-white/50 group-open:rotate-180 transition-transform">▾</span>
+                    </summary>
+                    <div class="absolute right-0 mt-2 w-72 max-h-72 overflow-y-auto rounded-2xl border border-cyan-300/20 bg-[#21112f] p-3 space-y-2 shadow-2xl z-30">
+                        <label class="flex items-center gap-2 text-sm text-white font-semibold">
+                            <input type="checkbox" name="tx_u" value="all" {% if tx_filter_raw == 'all' %}checked{% endif %}
+                                   class="tx-filter-all rounded border-white/20 bg-white/10">
+                            Tous les utilisateurs
+                        </label>
+                        <hr class="border-white/10">
                         {% for u in all_users %}
-                        <option value="{{ u.id }}" {% if tx_filter_raw == (u.id|string) %}selected{% endif %}>{{ u.username }}</option>
+                        <label class="flex items-center gap-2 text-sm text-white/85 font-semibold">
+                            <input type="checkbox" name="tx_u" value="{{ u.id }}" {% if u.id in tx_selected_user_ids %}checked{% endif %}
+                                   class="tx-filter-user rounded border-white/20 bg-white/10">
+                            {{ u.username }}
+                        </label>
                         {% endfor %}
-                    </select>
-                    <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-white/50">▾</span>
-                </div>
-                {% if user.is_admin and tx_filter_raw != 'all' %}
+                        <button type="submit" class="w-full mt-2 rounded-lg border border-cyan-300/40 bg-cyan-400/15 px-3 py-2 text-xs font-bold text-cyan-100 hover:bg-cyan-400/25 transition-colors">
+                            Appliquer
+                        </button>
+                    </div>
+                </details>
+                {% if tx_filter_raw != 'all' %}
                 <a href="/history?u={{ target_user.id }}#bitgroins"
                    class="inline-flex items-center gap-1 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-bold text-white/70 hover:bg-white/10 transition-colors">
                     Réinitialiser
@@ -273,8 +291,10 @@
             <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                     <h3 class="text-white text-xl font-extrabold">
-                        {% if user.is_admin and tx_filter_raw == 'all' %}
+                        {% if tx_filter_raw == 'all' %}
                         Journal global des utilisateurs 🪙 BitGroins
+                        {% elif tx_filter_users|length > 1 %}
+                        Journal de {{ tx_filter_users|length }} utilisateurs 🪙 BitGroins
                         {% elif tx_filter_user %}
                         Journal de {{ tx_filter_user.username }} 🪙 BitGroins
                         {% elif target_user.id == user.id %}
@@ -294,9 +314,7 @@
                     <thead>
                         <tr>
                             <th><button type="button" class="tx-sort-btn" data-sort-key="date">Date ↕</button></th>
-                            {% if user.is_admin %}
                             <th><button type="button" class="tx-sort-btn" data-sort-key="user">Utilisateur ↕</button></th>
-                            {% endif %}
                             <th><button type="button" class="tx-sort-btn" data-sort-key="amount">Mouvement ↕</button></th>
                             <th>Detail</th>
                             <th><button type="button" class="tx-sort-btn" data-sort-key="balance">Solde apres ↕</button></th>
@@ -307,9 +325,7 @@
                         {% set amount_color = 'text-emerald-300' if tx.amount > 0 else ('text-rose-300' if tx.amount < 0 else 'text-cyan-200') %}
                         <tr data-date="{{ tx.created_at.timestamp() }}" data-user="{{ (tx.user.username if tx.user else 'Utilisateur supprime')|lower }}" data-amount="{{ tx.amount }}" data-balance="{{ tx.balance_after or 0 }}">
                             <td class="text-white/70 text-sm font-bold whitespace-nowrap">{{ tx.created_at.strftime('%d/%m/%Y %H:%M') }}</td>
-                            {% if user.is_admin %}
                             <td class="text-white font-bold whitespace-nowrap">{{ tx.user.username if tx.user else 'Utilisateur supprime' }}</td>
-                            {% endif %}
                             <td>
                                 <p class="font-extrabold {{ amount_color }}">
                                     {% if tx.amount > 0 %}+{% endif %}{{ "%.2f"|format(tx.amount) }} 🪙
@@ -480,6 +496,35 @@
         sortRows(key, nextDir);
       });
     });
+  }
+
+  const allToggle = document.querySelector('.tx-filter-all');
+  const userToggles = Array.from(document.querySelectorAll('.tx-filter-user'));
+  if (allToggle && userToggles.length) {
+    const syncUserToggles = () => {
+      if (allToggle.checked) {
+        userToggles.forEach(cb => {
+          cb.checked = false;
+          cb.disabled = true;
+        });
+      } else {
+        userToggles.forEach(cb => {
+          cb.disabled = false;
+        });
+      }
+    };
+
+    allToggle.addEventListener('change', syncUserToggles);
+    userToggles.forEach(cb => {
+      cb.addEventListener('change', () => {
+        if (cb.checked) {
+          allToggle.checked = false;
+        }
+        syncUserToggles();
+      });
+    });
+
+    syncUserToggles();
   }
 })();
 </script>


### PR DESCRIPTION
### Motivation
- The BitGroins history filter was previously gated to admins and non-admins only saw a static "Mon journal uniquement" label, preventing users from using multi-user selection and global views.

### Description
- Backend: unified the filter parsing to use `request.args.getlist('tx_u')` and apply the same selection semantics for all users, building `tx_selected_user_ids` and applying `BalanceTransaction.user_id.in_(...)` when IDs are provided in `routes/main.py`.
- Frontend: removed the admin-only guard and expose the checkbox-based selector ("Tous les utilisateurs" + per-user checkboxes), preserved the reset link when a non-`all` filter is active, and always render the `Utilisateur` column in `templates/history.html`.
- UX: added client-side JS to sync the "Tous les utilisateurs" checkbox with individual user checkboxes (`.tx-filter-all` / `.tx-filter-user`) so selecting "all" disables individual boxes and selecting any user unchecks "all".
- Files changed: `routes/main.py`, `templates/history.html` (filter logic, template, and JS updates).

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_auth_logs.py` and all tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce26e5ba648323ba2067717d73e14d)