### PR TITLE
Add configurable server timezone for scheduling and admin UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       SECRET_KEY: ${SECRET_KEY:-change-me-in-production}
       FLASK_ENV: ${FLASK_ENV:-production}
       FLASK_DEBUG: "false"
+      TZ: ${DERBY_TIMEZONE:-Europe/Paris}
       DERBY_TIMEZONE: ${DERBY_TIMEZONE:-Europe/Paris}
       DERBY_FORCE_SCHEDULER: "1"
       # Mettre à "true" seulement si le site est servi en HTTPS (reverse proxy avec SSL)

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -87,6 +87,7 @@ def init_default_config():
         'market_duration': '120',
         'min_real_participants': '2',
         'empty_race_mode': 'fill',
+        'timezone': 'Europe/Paris',
     }
     for k, v in defaults.items():
         if not GameConfig.query.filter_by(key=k).first():

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -311,6 +311,7 @@ def admin_races(user):
             'market_duration': settings.market_duration,
             'min_real_participants': settings.min_real_participants,
             'empty_race_mode': settings.empty_race_mode,
+            'timezone': get_config('timezone', 'Europe/Paris'),
             'race_schedule': settings.race_schedule,
             'schedule_dict': settings.schedule_dict,
             'race_themes': merged_themes,
@@ -324,7 +325,7 @@ def admin_races(user):
 def admin_save(user):
     keys = [
         'race_hour', 'race_minute', 'market_hour',
-        'market_minute', 'market_duration', 'min_real_participants', 'empty_race_mode'
+        'market_minute', 'market_duration', 'min_real_participants', 'empty_race_mode', 'timezone'
     ]
     for key in keys:
         val = request.form.get(key)

--- a/templates/admin_races.html
+++ b/templates/admin_races.html
@@ -77,6 +77,18 @@
                 </div>
             </div>
 
+            <h2 class="font-title text-xl text-white mb-3 mt-6">🌍 Fuseau Horaire</h2>
+            <div class="mb-4">
+                <label for="timezone" class="text-white/60 text-xs font-bold block mb-1">Fuseau Horaire du Serveur</label>
+                <select class="input-admin w-full" id="timezone" name="timezone">
+                    <option value="Europe/Paris" {% if config.timezone == 'Europe/Paris' %}selected{% endif %}>Europe/Paris (France)</option>
+                    <option value="America/Montreal" {% if config.timezone == 'America/Montreal' %}selected{% endif %}>America/Montreal (Quebec)</option>
+                    <option value="Indian/Reunion" {% if config.timezone == 'Indian/Reunion' %}selected{% endif %}>Indian/Reunion (La Reunion)</option>
+                    <option value="Pacific/Noumea" {% if config.timezone == 'Pacific/Noumea' %}selected{% endif %}>Pacific/Noumea (Nouvelle-Caledonie)</option>
+                </select>
+                <p class="text-white/30 text-[10px] font-semibold mt-1">Ce fuseau est utilise pour l'heure des courses, du marche et la treve du week-end.</p>
+            </div>
+
             <h2 id="npcs" class="font-title text-xl text-white mb-3 mt-6">🐷 PNJ de remplissage</h2>
             <p class="text-white/40 text-xs font-semibold mb-2">Une ligne par PNJ au format <code>Nom|Emoji</code>. Si l'emoji est omis, 🐷 est utilise.</p>
             <div class="flex flex-wrap gap-2 mb-2">

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,22 +1,32 @@
 from datetime import datetime, time, timedelta
 from zoneinfo import ZoneInfo
+from helpers.config import get_config
 
-PARIS_TZ = ZoneInfo('Europe/Paris')
 WEEKEND_TRUCE_START = time(18, 0)
 WEEKEND_TRUCE_END = time(8, 0)
 WEEKEND_TRUCE_DURATION = timedelta(days=2, hours=14)
 
 
+def get_current_tz():
+    """Récupère le fuseau horaire depuis la base de données avec un fallback."""
+    try:
+        tz_str = get_config('timezone', 'Europe/Paris')
+        return ZoneInfo(tz_str)
+    except Exception:
+        return ZoneInfo('Europe/Paris')
+
+
 def get_paris_now():
-    return datetime.now(PARIS_TZ)
+    return datetime.now(get_current_tz())
 
 
 def to_paris_time(dt):
     if dt is None:
         return None
+    tz = get_current_tz()
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=ZoneInfo('UTC')).astimezone(PARIS_TZ)
-    return dt.astimezone(PARIS_TZ)
+        return dt.replace(tzinfo=ZoneInfo('UTC')).astimezone(tz)
+    return dt.astimezone(tz)
 
 
 def is_weekend_truce_active(moment=None):
@@ -36,7 +46,7 @@ def _next_weekend_truce_start(after_local):
     candidate_day = after_local.date()
     days_until_friday = (4 - after_local.weekday()) % 7
     candidate_day = candidate_day + timedelta(days=days_until_friday)
-    candidate_start = datetime.combine(candidate_day, WEEKEND_TRUCE_START, tzinfo=PARIS_TZ)
+    candidate_start = datetime.combine(candidate_day, WEEKEND_TRUCE_START, tzinfo=get_current_tz())
     if candidate_start <= after_local:
         candidate_start += timedelta(days=7)
     return candidate_start
@@ -55,7 +65,7 @@ def _get_current_truce_window_start(local_moment):
     return datetime.combine(
         local_moment.date() - timedelta(days=delta_days),
         WEEKEND_TRUCE_START,
-        tzinfo=PARIS_TZ,
+        tzinfo=get_current_tz(),
     )
 
 


### PR DESCRIPTION
### Motivation

- Permettre de configurer dynamiquement le fuseau horaire de l’application via la table `GameConfig` afin que la planification des courses, du marché et la trêve week-end utilisent un fuseau administrable depuis l’interface.
- Fournir une valeur par défaut robuste (`Europe/Paris`) pour les nouvelles installations afin d’éviter les comportements non déterministes.
- Harmoniser l’horodatage des logs du conteneur avec la configuration de l’application en exposant la variable système `TZ` au service web.

### Description

- Ajout de la clé de configuration par défaut `timezone` avec la valeur `Europe/Paris` dans `helpers/config.py` (`init_default_config`).
- Refactor de `utils/time_utils.py` pour remplacer le fuseau statique par une fonction `get_current_tz()` qui lit `get_config('timezone', 'Europe/Paris')`, et utilisation de cette fonction dans `get_paris_now`, `to_paris_time`, `_next_weekend_truce_start` et `_get_current_truce_window_start`.
- Exposition de la valeur de timezone au template admin en ajoutant `"timezone": get_config('timezone', 'Europe/Paris')` au contexte rendu par la route `admin_races` dans `routes/admin.py` et ajout de `timezone` à la liste de clés traitées par la route POST `/admin/save`.
- Ajout d’un menu déroulant `timezone` dans le template `templates/admin_races.html` (options: `Europe/Paris`, `America/Montreal`, `Indian/Reunion`, `Pacific/Noumea`) pour permettre la sélection depuis l’interface.
- Ajout de la variable d’environnement système `TZ: ${DERBY_TIMEZONE:-Europe/Paris}` dans `docker-compose.yml` pour aligner l’horloge du conteneur sur la configuration de l’application.

### Testing

- Compilation des modules modifiés avec `python -m compileall helpers/config.py utils/time_utils.py routes/admin.py templates/admin_races.html docker-compose.yml` réussie.
- Tentative de lancement des tests avec `pytest -q tests/test_race_engine.py` a d’abord échoué à la collecte à cause d’un `ModuleNotFoundError` lié à l’absence de `PYTHONPATH` configuré, puis les tests ont été relancés avec `PYTHONPATH=. pytest -q tests/test_race_engine.py` et ont réussi (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce48307c50832383a2b5a62e802eab)