### PR TITLE
Add configurable server timezone with admin UI and timezone-aware utilities

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       SECRET_KEY: ${SECRET_KEY:-change-me-in-production}
       FLASK_ENV: ${FLASK_ENV:-production}
       FLASK_DEBUG: "false"
+      TZ: ${DERBY_TIMEZONE:-Europe/Paris}
       DERBY_TIMEZONE: ${DERBY_TIMEZONE:-Europe/Paris}
       DERBY_FORCE_SCHEDULER: "1"
       # Mettre à "true" seulement si le site est servi en HTTPS (reverse proxy avec SSL)

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -87,6 +87,7 @@ def init_default_config():
         'market_duration': '120',
         'min_real_participants': '2',
         'empty_race_mode': 'fill',
+        'timezone': 'Europe/Paris',
     }
     for k, v in defaults.items():
         if not GameConfig.query.filter_by(key=k).first():

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -155,9 +155,10 @@ def admin_dashboard(user):
         'admin_count': User.query.filter_by(is_admin=True).count(),
     }
     recent_races = Race.query.filter_by(status='finished').order_by(Race.finished_at.desc()).limit(8).all()
+    current_timezone = get_config('timezone', 'Europe/Paris')
 
     return render_template('admin_dashboard.html',
-        user=user, admin_tab='dashboard', stats=stats, recent_races=recent_races)
+        user=user, admin_tab='dashboard', stats=stats, recent_races=recent_races, current_timezone=current_timezone)
 
 
 @admin_bp.route('/admin/auth-logs')
@@ -311,6 +312,7 @@ def admin_races(user):
             'market_duration': settings.market_duration,
             'min_real_participants': settings.min_real_participants,
             'empty_race_mode': settings.empty_race_mode,
+            'timezone': get_config('timezone', 'Europe/Paris'),
             'race_schedule': settings.race_schedule,
             'schedule_dict': settings.schedule_dict,
             'race_themes': merged_themes,
@@ -324,7 +326,7 @@ def admin_races(user):
 def admin_save(user):
     keys = [
         'race_hour', 'race_minute', 'market_hour',
-        'market_minute', 'market_duration', 'min_real_participants', 'empty_race_mode'
+        'market_minute', 'market_duration', 'min_real_participants', 'empty_race_mode', 'timezone'
     ]
     for key in keys:
         val = request.form.get(key)

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -73,6 +73,25 @@
     </div>
 </div>
 
+<!-- CONFIG FUSEAU -->
+<div class="card p-6 mb-8">
+    <h2 class="font-title text-xl text-white mb-2">🌍 Fuseau horaire serveur</h2>
+    <p class="text-white/40 text-xs font-semibold mb-4">Utilise pour les courses, le marche et la treve du week-end.</p>
+    <form method="POST" action="{{ url_for('admin.admin_save') }}" class="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-3 items-end">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div>
+            <label for="timezone" class="text-white/60 text-xs font-bold block mb-1">Fuseau Horaire</label>
+            <select class="input-admin w-full" id="timezone" name="timezone">
+                <option value="Europe/Paris" {% if current_timezone == 'Europe/Paris' %}selected{% endif %}>Europe/Paris (France)</option>
+                <option value="America/Montreal" {% if current_timezone == 'America/Montreal' %}selected{% endif %}>America/Montreal (Quebec)</option>
+                <option value="Indian/Reunion" {% if current_timezone == 'Indian/Reunion' %}selected{% endif %}>Indian/Reunion (La Reunion)</option>
+                <option value="Pacific/Noumea" {% if current_timezone == 'Pacific/Noumea' %}selected{% endif %}>Pacific/Noumea (Nouvelle-Caledonie)</option>
+            </select>
+        </div>
+        <button type="submit" class="btn-admin">💾 Sauvegarder</button>
+    </form>
+</div>
+
 <!-- ACTIONS RAPIDES -->
 <div class="card p-6">
     <h2 class="font-title text-xl text-white mb-4">⚡ Actions rapides</h2>

--- a/templates/admin_races.html
+++ b/templates/admin_races.html
@@ -77,6 +77,18 @@
                 </div>
             </div>
 
+            <h2 class="font-title text-xl text-white mb-3 mt-6">🌍 Fuseau Horaire</h2>
+            <div class="mb-4">
+                <label for="timezone" class="text-white/60 text-xs font-bold block mb-1">Fuseau Horaire du Serveur</label>
+                <select class="input-admin w-full" id="timezone" name="timezone">
+                    <option value="Europe/Paris" {% if config.timezone == 'Europe/Paris' %}selected{% endif %}>Europe/Paris (France)</option>
+                    <option value="America/Montreal" {% if config.timezone == 'America/Montreal' %}selected{% endif %}>America/Montreal (Quebec)</option>
+                    <option value="Indian/Reunion" {% if config.timezone == 'Indian/Reunion' %}selected{% endif %}>Indian/Reunion (La Reunion)</option>
+                    <option value="Pacific/Noumea" {% if config.timezone == 'Pacific/Noumea' %}selected{% endif %}>Pacific/Noumea (Nouvelle-Caledonie)</option>
+                </select>
+                <p class="text-white/30 text-[10px] font-semibold mt-1">Ce fuseau est utilise pour l'heure des courses, du marche et la treve du week-end.</p>
+            </div>
+
             <h2 id="npcs" class="font-title text-xl text-white mb-3 mt-6">🐷 PNJ de remplissage</h2>
             <p class="text-white/40 text-xs font-semibold mb-2">Une ligne par PNJ au format <code>Nom|Emoji</code>. Si l'emoji est omis, 🐷 est utilise.</p>
             <div class="flex flex-wrap gap-2 mb-2">

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,22 +1,32 @@
 from datetime import datetime, time, timedelta
 from zoneinfo import ZoneInfo
+from helpers.config import get_config
 
-PARIS_TZ = ZoneInfo('Europe/Paris')
 WEEKEND_TRUCE_START = time(18, 0)
 WEEKEND_TRUCE_END = time(8, 0)
 WEEKEND_TRUCE_DURATION = timedelta(days=2, hours=14)
 
 
+def get_current_tz():
+    """Récupère le fuseau horaire depuis la base de données avec un fallback."""
+    try:
+        tz_str = get_config('timezone', 'Europe/Paris')
+        return ZoneInfo(tz_str)
+    except Exception:
+        return ZoneInfo('Europe/Paris')
+
+
 def get_paris_now():
-    return datetime.now(PARIS_TZ)
+    return datetime.now(get_current_tz())
 
 
 def to_paris_time(dt):
     if dt is None:
         return None
+    tz = get_current_tz()
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=ZoneInfo('UTC')).astimezone(PARIS_TZ)
-    return dt.astimezone(PARIS_TZ)
+        return dt.replace(tzinfo=ZoneInfo('UTC')).astimezone(tz)
+    return dt.astimezone(tz)
 
 
 def is_weekend_truce_active(moment=None):
@@ -36,7 +46,7 @@ def _next_weekend_truce_start(after_local):
     candidate_day = after_local.date()
     days_until_friday = (4 - after_local.weekday()) % 7
     candidate_day = candidate_day + timedelta(days=days_until_friday)
-    candidate_start = datetime.combine(candidate_day, WEEKEND_TRUCE_START, tzinfo=PARIS_TZ)
+    candidate_start = datetime.combine(candidate_day, WEEKEND_TRUCE_START, tzinfo=get_current_tz())
     if candidate_start <= after_local:
         candidate_start += timedelta(days=7)
     return candidate_start
@@ -55,7 +65,7 @@ def _get_current_truce_window_start(local_moment):
     return datetime.combine(
         local_moment.date() - timedelta(days=delta_days),
         WEEKEND_TRUCE_START,
-        tzinfo=PARIS_TZ,
+        tzinfo=get_current_tz(),
     )
 
 


### PR DESCRIPTION
### Motivation
- Centralize server timezone so race scheduling, market times and the weekend truce behave correctly for deployments in different zones.
- Provide administrators a UI to view and change the server timezone without editing environment files.

### Description
- Add a `timezone` default (`Europe/Paris`) to `init_default_config` in `helpers/config.py` so the setting is persisted in `GameConfig` when missing.
- Expose timezone selection in admin interfaces by adding a timezone selector to `admin_dashboard.html` and `admin_races.html`, and include `timezone` in the save keys handled by `admin_save` in `routes/admin.py`.
- Make time handling timezone-aware by adding `get_current_tz()` in `utils/time_utils.py` (reads `timezone` via `get_config`) and update `get_paris_now`, `to_paris_time`, and weekend-truce helper functions to use the configured timezone.
- Add container runtime support by setting `TZ` in `docker-compose.yml` from `DERBY_TIMEZONE` and keep `DERBY_TIMEZONE` env var for backward compatibility.

### Testing
- Ran the project test suite with `pytest` and verified all tests passed.
- Ran static checks and basic Flask template rendering smoke tests (`pytest` template tests) with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce48307c50832383a2b5a62e802eab)