### PR TITLE
Porcherie : onglets de sélection et persistance (Ma Porcherie)

### DIFF
--- a/templates/_site_header.html
+++ b/templates/_site_header.html
@@ -78,7 +78,7 @@
                 <button id="chat-toggle" class="{{ nav_base }} border-indigo-400/30 bg-indigo-500/10 text-indigo-100 hover:bg-indigo-500/20">💬 Chat</button>
                 <a href="/courses" class="{{ nav_base }} {{ nav_active if active_page == 'courses' else nav_idle }}">📅 Courses</a>
                 <a href="/paris" class="{{ nav_base }} {{ nav_active if active_page == 'paris' else nav_idle }}">💰 Paris</a>
-                <a href="/mon-cochon" class="{{ nav_base }} {{ nav_active if active_page == 'mon_cochon' else nav_idle }}">🐷 Mon Cochon</a>
+                <a href="/mon-cochon" class="{{ nav_base }} {{ nav_active if active_page == 'mon_cochon' else nav_idle }}">🛖 Ma Porcherie</a>
                 <a href="/regles" class="{{ nav_base }} {{ nav_active if active_page == 'regles' else nav_idle }}">📘 Règles</a>
                 <a href="/veterinaire" class="{{ nav_base }} {{ 'border-red-400/35 bg-red-500/15 text-red-100 shadow-[0_8px_24px_rgba(248,113,113,0.12)]' if injured_pig_nav_id else (nav_active if active_page == 'veterinaire' else nav_idle) }}">{{ '🏥 Véto urgent' if injured_pig_nav_id else '🏥 Vétérinaire' }}</a>
                 <a href="/bourse" class="{{ nav_base }} {{ nav_active if active_page == 'bourse' else nav_idle }}">🌾 Bourse</a>

--- a/templates/mon_cochon.html
+++ b/templates/mon_cochon.html
@@ -166,13 +166,28 @@
             <p class="text-white/35 text-xs font-bold mt-2">Quand ton solde tombe trop bas, le jeu verse automatiquement une petite prime d'urgence pour t'éviter le soft-lock.</p>
         </div>
         {% endif %}
+        {% if pigs_data|length > 1 %}
+        <div class="flex flex-wrap items-center justify-center gap-3 mb-8">
+            {% for pd in pigs_data %}
+            <button onclick="switchPig('{{ pd.pig.id }}')" id="btn-select-pig-{{ pd.pig.id }}"
+                    class="pig-tab-btn flex items-center gap-2 px-5 py-2.5 rounded-xl font-bold transition-all border border-pink-500/30 bg-pink-500/10 text-pink-200 hover:bg-pink-500/20 hover:-translate-y-1">
+                <span class="text-xl">{{ pd.pig.emoji }}</span>
+                <span>{{ pd.pig.name }}</span>
+                {% if pd.pig.is_injured %}
+                <span class="text-red-500 text-xs animate-pulse" title="Blessé">🚨</span>
+                {% endif %}
+            </button>
+            {% endfor %}
+        </div>
+        {% endif %}
+
         {% for pd in pigs_data %}
         {% set pig = pd.pig %}
         {% set injury_risk = pig.injury_risk or 10.0 %}
         {% set weight_profile = pd.weight_profile %}
         {% set freshness = pd.freshness_bonus %}
         {% set performance_flags = pd.performance_flags %}
-        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8 p-1 relative">
+        <div id="pig-wrapper-{{ pd.pig.id }}" class="pig-wrapper {% if loop.index0 > 0 %}hidden{% endif %} grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8 p-1 relative">
             
             <!-- LEFT COLUMN: Main ID Card -->
             <div class="xl:col-span-1">
@@ -758,6 +773,31 @@
         document.getElementById('avatar-input-' + pigId).value = avatarId;
     }
 
+    // Gestion du basculement entre les cochons de la porcherie
+    function switchPig(pigId) {
+        document.querySelectorAll('.pig-wrapper').forEach(el => {
+            el.classList.add('hidden');
+        });
+
+        const targetWrapper = document.getElementById('pig-wrapper-' + pigId);
+        if (targetWrapper) {
+            targetWrapper.classList.remove('hidden');
+        }
+
+        document.querySelectorAll('.pig-tab-btn').forEach(btn => {
+            btn.classList.remove('bg-pink-500/40', 'border-pink-400');
+            btn.classList.add('bg-pink-500/10', 'border-pink-500/30');
+        });
+
+        const activeBtn = document.getElementById('btn-select-pig-' + pigId);
+        if (activeBtn) {
+            activeBtn.classList.remove('bg-pink-500/10', 'border-pink-500/30');
+            activeBtn.classList.add('bg-pink-500/40', 'border-pink-400');
+        }
+
+        localStorage.setItem('derby_selected_pig', pigId);
+    }
+
     const _vetTimers = [];
 
     function startVetCountdowns() {
@@ -783,6 +823,19 @@
             }, 1000));
         });
     }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const savedPigId = localStorage.getItem('derby_selected_pig');
+        if (savedPigId && document.getElementById('pig-wrapper-' + savedPigId)) {
+            switchPig(savedPigId);
+        } else {
+            const firstBtn = document.querySelector('.pig-tab-btn');
+            if (firstBtn) {
+                firstBtn.classList.remove('bg-pink-500/10', 'border-pink-500/30');
+                firstBtn.classList.add('bg-pink-500/40', 'border-pink-400');
+            }
+        }
+    });
 
     startVetCountdowns();
     window.addEventListener('beforeunload', () => _vetTimers.forEach(clearInterval));


### PR DESCRIPTION
### Motivation
- Améliorer l'expérience de la porcherie en renommant l'entrée de navigation pour la rendre plus sémantique et en permettant de passer instantanément d'un cochon à l'autre sans rechargement de page.
- Garder la compatibilité des routes existantes tout en réduisant le bruit UI quand plusieurs cochons sont présents.

### Description
- Mise à jour du libellé de navigation dans `templates/_site_header.html` pour afficher `🛖 Ma Porcherie` sans modifier la route `/mon-cochon`.
- Ajout dans `templates/mon_cochon.html` d'une barre d'onglets (boutons avec la classe `pig-tab-btn`) affichée quand `pigs_data|length > 1`, incluant un indicateur visuel pour les cochons blessés.
- Enveloppement de chaque fiche cochon dans un conteneur `div` identifié par `id="pig-wrapper-{{ pd.pig.id }}"` et classé `pig-wrapper`, avec tous les conteneurs sauf le premier masqués par défaut pour permettre l'affichage par onglet.
- Ajout du script client `switchPig(pigId)` qui masque/affiche les wrappers, met à jour le style des boutons et persiste la sélection dans `localStorage` sous la clé `derby_selected_pig`, ainsi que d'une initialisation sur `DOMContentLoaded` qui restaure la sélection ou active le premier onglet.

### Testing
- Vérification des modifications par recherche ciblée avec `rg -n` pour les motifs ajoutés (`Ma Porcherie`, `pig-tab-btn`, `pig-wrapper-`, `switchPig`, `derby_selected_pig`) et les fichiers modifiés, et la recherche a trouvé les insertions attendues.
- Contrôle de l'état Git avec `git status --short` et inspection du diff via `git show --stat --oneline HEAD`, confirmant les deux fichiers modifiés et le commit réalisé avec succès.
- Vérification finale du contenu des fichiers modifiés avec `nl -ba` pour s'assurer que les blocs HTML/JS ont bien été injectés aux bons emplacements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce516548ec83239351f9b103541ff6)