### PR TITLE
Add configurable server timezone and preserve local race times on change

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       SECRET_KEY: ${SECRET_KEY:-change-me-in-production}
       FLASK_ENV: ${FLASK_ENV:-production}
       FLASK_DEBUG: "false"
+      TZ: ${DERBY_TIMEZONE:-Europe/Paris}
       DERBY_TIMEZONE: ${DERBY_TIMEZONE:-Europe/Paris}
       DERBY_FORCE_SCHEDULER: "1"
       # Mettre à "true" seulement si le site est servi en HTTPS (reverse proxy avec SSL)

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -87,6 +87,7 @@ def init_default_config():
         'market_duration': '120',
         'min_real_participants': '2',
         'empty_race_mode': 'fill',
+        'timezone': 'Europe/Paris',
     }
     for k, v in defaults.items():
         if not GameConfig.query.filter_by(key=k).first():

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash, make_response
 from werkzeug.security import generate_password_hash
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import csv
 import io
 import json
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import secrets
+from zoneinfo import ZoneInfo
 
 from extensions import db
 from models import User, Race, Pig, Bet, CerealItem, TrainingItem, SchoolLessonItem, PigAvatar, AuthEventLog
@@ -155,9 +156,10 @@ def admin_dashboard(user):
         'admin_count': User.query.filter_by(is_admin=True).count(),
     }
     recent_races = Race.query.filter_by(status='finished').order_by(Race.finished_at.desc()).limit(8).all()
+    current_timezone = get_config('timezone', 'Europe/Paris')
 
     return render_template('admin_dashboard.html',
-        user=user, admin_tab='dashboard', stats=stats, recent_races=recent_races)
+        user=user, admin_tab='dashboard', stats=stats, recent_races=recent_races, current_timezone=current_timezone)
 
 
 @admin_bp.route('/admin/auth-logs')
@@ -311,6 +313,7 @@ def admin_races(user):
             'market_duration': settings.market_duration,
             'min_real_participants': settings.min_real_participants,
             'empty_race_mode': settings.empty_race_mode,
+            'timezone': get_config('timezone', 'Europe/Paris'),
             'race_schedule': settings.race_schedule,
             'schedule_dict': settings.schedule_dict,
             'race_themes': merged_themes,
@@ -322,6 +325,7 @@ def admin_races(user):
 @admin_bp.route('/admin/save', methods=['POST'])
 @admin_required
 def admin_save(user):
+    old_timezone = get_config('timezone', 'Europe/Paris')
     keys = [
         'race_hour', 'race_minute', 'market_hour',
         'market_minute', 'market_duration', 'min_real_participants', 'empty_race_mode'
@@ -330,6 +334,42 @@ def admin_save(user):
         val = request.form.get(key)
         if val is not None:
             set_config(key, val)
+
+    new_timezone = (request.form.get('timezone') or '').strip()
+    if new_timezone:
+        try:
+            old_tz = ZoneInfo(old_timezone)
+            new_tz = ZoneInfo(new_timezone)
+        except Exception:
+            flash("Fuseau horaire invalide. Aucun changement applique.", "error")
+            return redirect(url_for('admin.admin_races'))
+
+        if new_timezone != old_timezone:
+            upcoming_races = Race.query.filter(
+                Race.status.in_(['upcoming', 'open']),
+                Race.scheduled_at.isnot(None),
+            ).all()
+            for race in upcoming_races:
+                scheduled_utc = race.scheduled_at
+                if scheduled_utc.tzinfo is None:
+                    scheduled_utc = scheduled_utc.replace(tzinfo=timezone.utc)
+                else:
+                    scheduled_utc = scheduled_utc.astimezone(timezone.utc)
+
+                old_local = scheduled_utc.astimezone(old_tz)
+                preserved_local = datetime(
+                    old_local.year, old_local.month, old_local.day,
+                    old_local.hour, old_local.minute, old_local.second, old_local.microsecond,
+                    tzinfo=new_tz,
+                )
+                race.scheduled_at = preserved_local.astimezone(timezone.utc).replace(tzinfo=None)
+
+            db.session.commit()
+            set_config('timezone', new_timezone)
+            flash("Fuseau horaire mis a jour. Les courses a venir ont ete recalees pour garder les memes heures locales.", "success")
+            flash("Note logs Docker: pour aligner l'heure systeme (TZ), redemarre le conteneur web.", "info")
+        else:
+            set_config('timezone', new_timezone)
 
     # Jours du marché : checkboxes multi-valeurs → "1,3,4"
     market_days = request.form.getlist('market_days')

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -73,6 +73,25 @@
     </div>
 </div>
 
+<!-- CONFIG FUSEAU -->
+<div class="card p-6 mb-8">
+    <h2 class="font-title text-xl text-white mb-2">🌍 Fuseau horaire serveur</h2>
+    <p class="text-white/40 text-xs font-semibold mb-4">Utilise pour les courses, le marche et la treve du week-end.</p>
+    <form method="POST" action="{{ url_for('admin.admin_save') }}" class="grid grid-cols-1 sm:grid-cols-[1fr_auto] gap-3 items-end">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <div>
+            <label for="timezone" class="text-white/60 text-xs font-bold block mb-1">Fuseau Horaire</label>
+            <select class="input-admin w-full" id="timezone" name="timezone">
+                <option value="Europe/Paris" {% if current_timezone == 'Europe/Paris' %}selected{% endif %}>Europe/Paris (France)</option>
+                <option value="America/Montreal" {% if current_timezone == 'America/Montreal' %}selected{% endif %}>America/Montreal (Quebec)</option>
+                <option value="Indian/Reunion" {% if current_timezone == 'Indian/Reunion' %}selected{% endif %}>Indian/Reunion (La Reunion)</option>
+                <option value="Pacific/Noumea" {% if current_timezone == 'Pacific/Noumea' %}selected{% endif %}>Pacific/Noumea (Nouvelle-Caledonie)</option>
+            </select>
+        </div>
+        <button type="submit" class="btn-admin">💾 Sauvegarder</button>
+    </form>
+</div>
+
 <!-- ACTIONS RAPIDES -->
 <div class="card p-6">
     <h2 class="font-title text-xl text-white mb-4">⚡ Actions rapides</h2>

--- a/templates/admin_races.html
+++ b/templates/admin_races.html
@@ -77,6 +77,18 @@
                 </div>
             </div>
 
+            <h2 class="font-title text-xl text-white mb-3 mt-6">🌍 Fuseau Horaire</h2>
+            <div class="mb-4">
+                <label for="timezone" class="text-white/60 text-xs font-bold block mb-1">Fuseau Horaire du Serveur</label>
+                <select class="input-admin w-full" id="timezone" name="timezone">
+                    <option value="Europe/Paris" {% if config.timezone == 'Europe/Paris' %}selected{% endif %}>Europe/Paris (France)</option>
+                    <option value="America/Montreal" {% if config.timezone == 'America/Montreal' %}selected{% endif %}>America/Montreal (Quebec)</option>
+                    <option value="Indian/Reunion" {% if config.timezone == 'Indian/Reunion' %}selected{% endif %}>Indian/Reunion (La Reunion)</option>
+                    <option value="Pacific/Noumea" {% if config.timezone == 'Pacific/Noumea' %}selected{% endif %}>Pacific/Noumea (Nouvelle-Caledonie)</option>
+                </select>
+                <p class="text-white/30 text-[10px] font-semibold mt-1">Ce fuseau est utilise pour l'heure des courses, du marche et la treve du week-end.</p>
+            </div>
+
             <h2 id="npcs" class="font-title text-xl text-white mb-3 mt-6">🐷 PNJ de remplissage</h2>
             <p class="text-white/40 text-xs font-semibold mb-2">Une ligne par PNJ au format <code>Nom|Emoji</code>. Si l'emoji est omis, 🐷 est utilise.</p>
             <div class="flex flex-wrap gap-2 mb-2">

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -1,22 +1,32 @@
 from datetime import datetime, time, timedelta
 from zoneinfo import ZoneInfo
+from helpers.config import get_config
 
-PARIS_TZ = ZoneInfo('Europe/Paris')
 WEEKEND_TRUCE_START = time(18, 0)
 WEEKEND_TRUCE_END = time(8, 0)
 WEEKEND_TRUCE_DURATION = timedelta(days=2, hours=14)
 
 
+def get_current_tz():
+    """Récupère le fuseau horaire depuis la base de données avec un fallback."""
+    try:
+        tz_str = get_config('timezone', 'Europe/Paris')
+        return ZoneInfo(tz_str)
+    except Exception:
+        return ZoneInfo('Europe/Paris')
+
+
 def get_paris_now():
-    return datetime.now(PARIS_TZ)
+    return datetime.now(get_current_tz())
 
 
 def to_paris_time(dt):
     if dt is None:
         return None
+    tz = get_current_tz()
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=ZoneInfo('UTC')).astimezone(PARIS_TZ)
-    return dt.astimezone(PARIS_TZ)
+        return dt.replace(tzinfo=ZoneInfo('UTC')).astimezone(tz)
+    return dt.astimezone(tz)
 
 
 def is_weekend_truce_active(moment=None):
@@ -36,7 +46,7 @@ def _next_weekend_truce_start(after_local):
     candidate_day = after_local.date()
     days_until_friday = (4 - after_local.weekday()) % 7
     candidate_day = candidate_day + timedelta(days=days_until_friday)
-    candidate_start = datetime.combine(candidate_day, WEEKEND_TRUCE_START, tzinfo=PARIS_TZ)
+    candidate_start = datetime.combine(candidate_day, WEEKEND_TRUCE_START, tzinfo=get_current_tz())
     if candidate_start <= after_local:
         candidate_start += timedelta(days=7)
     return candidate_start
@@ -55,7 +65,7 @@ def _get_current_truce_window_start(local_moment):
     return datetime.combine(
         local_moment.date() - timedelta(days=delta_days),
         WEEKEND_TRUCE_START,
-        tzinfo=PARIS_TZ,
+        tzinfo=get_current_tz(),
     )
 
 


### PR DESCRIPTION
### Motivation
- Make the server timezone configurable so race times, market and weekend truce logic can be adapted to different deployments. 
- Preserve local scheduled race hours when the server timezone is changed to avoid unintentionally shifting race times for players. 
- Replace hardcoded `Europe/Paris` usage with a configurable fallback read from game configuration. 

### Description
- Add `TZ` environment variable to `docker-compose.yml` and set the `timezone` default in `init_default_config()` to `Europe/Paris`. 
- Expose and save the server timezone in admin UI by adding a timezone selector to `admin_dashboard.html` and `admin_races.html`, and pass `current_timezone` from `admin_dashboard`. 
- Implement timezone-change handling in `admin_save` to validate the new zone, convert all upcoming/open races (`Race.scheduled_at`) so their local hours are preserved when the timezone changes, commit updates and set the `timezone` config. 
- Replace hardcoded Paris timezone in `utils/time_utils.py` with `get_current_tz()` that reads `timezone` from config and update `get_paris_now`, `to_paris_time`, `_next_weekend_truce_start`, and `_get_current_truce_window_start` to use the dynamic timezone. 

### Testing
- Ran the project's unit test suite with `pytest` and the linter `flake8`, and they completed successfully. 
- Exercised admin timezone change path in a local dev instance to confirm upcoming races are adjusted to preserve the same local clock time and the `timezone` config is updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce48307c50832383a2b5a62e802eab)